### PR TITLE
Refactor `Fetch` to support custom GuzzleHttp clients

### DIFF
--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -21,26 +21,53 @@ class FetchTest extends TestCase
     }
 
     /**
-     * Test `get()` with URL that does not return an rss feed
+     * Test `get()` with mock handler that does not return a rss feed
      */
     public function testGetParseError(): void
     {
+        $mock = new GuzzleHttp\Handler\MockHandler([
+            new GuzzleHttp\Psr7\Response(200, body: 'Hello, World'),
+        ]);
+        $handlerStack = GuzzleHttp\HandlerStack::create($mock);
+
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to parse feed');
 
-        $fetch = new Fetch();
-        $fetch->get('https://example.com');
+        $fetch = new Fetch(new \GuzzleHttp\Client(['handler' => $handlerStack]));
+        $fetch->get('http://example.invalid');
     }
 
     /**
-     * Test `get()` with URL that returns HTTP 500
+     * Test `get()` with mock handler that returns HTTP 500
      */
     public function testGetServerError(): void
     {
-        $this->expectException(FetchException::class);
-        $this->expectExceptionMessage('Failed to fetch: https://httpbingo.org/status/500');
+        $mock = new GuzzleHttp\Handler\MockHandler([
+            new GuzzleHttp\Psr7\Response(500, body: 'server error'),
+        ]);
+        $handlerStack = GuzzleHttp\HandlerStack::create($mock);
 
-        $fetch = new Fetch();
-        $fetch->get('https://httpbingo.org/status/500');
+        $this->expectException(FetchException::class);
+        $this->expectExceptionMessage('ailed to fetch: http://example.invalid (500 Internal Server Error)');
+
+        $fetch = new Fetch(new \GuzzleHttp\Client(['handler' => $handlerStack]));
+        $fetch->get('http://example.invalid');
+    }
+
+    /**
+     * Test `get()` with mock handler that returns HTTP 404
+     */
+    public function testGetNotFoundError(): void
+    {
+        $mock = new GuzzleHttp\Handler\MockHandler([
+            new GuzzleHttp\Psr7\Response(404, body: 'not found'),
+        ]);
+        $handlerStack = GuzzleHttp\HandlerStack::create($mock);
+
+        $this->expectException(FetchException::class);
+        $this->expectExceptionMessage('Failed to fetch: http://example.invalid (404 Not Found)');
+
+        $fetch = new Fetch(new \GuzzleHttp\Client(['handler' => $handlerStack]));
+        $fetch->get('http://example.invalid');
     }
 }


### PR DESCRIPTION
Refactor `Fetch` class to support passing `GuzzleHttp` clients and to improve error handling 