### PR TITLE
Add Ntfy priority environment variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,10 +41,11 @@ To use Gotify, a URL and application token must be given.
 
 To use Ntfy, a URL and topic must be given, all other environment variable are optional.
 
-| Name                                 | Description            |
-| ------------------------------------ | ---------------------- |
-| `VIGILANT_NOTIFICATION_NTFY_URL`   | URL used to access Ntfy. |
-| `VIGILANT_NOTIFICATION_NTFY_TOPIC` | Ntfy topic.              |
+| Name                                  | Description                                                                             |
+| ------------------------------------- | --------------------------------------------------------------------------------------- |
+| `VIGILANT_NOTIFICATION_NTFY_URL`      | URL used to access Ntfy.                                                                |
+| `VIGILANT_NOTIFICATION_NTFY_TOPIC`    | Ntfy topic.                                                                             |
+| `VIGILANT_NOTIFICATION_NTFY_PRIORITY` | Ntfy [message priority](https://docs.ntfy.sh/publish/#message-priority). Defaults to 3. |
 
 Vigilant can be used a with ntfy server that has password or [access token](https://docs.ntfy.sh/config/#access-tokens) authentication enabled.
 

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -29,4 +29,4 @@ feeds:
 | `gotify_priority` | No       | Gotify message priority.                                                      |
 | `ntfy_topic`      | No       | Ntfy topic. Overrides topic set with an environment variable.                 |
 | `ntfy_token`      | No       | Ntfy access token. Overrides token set with an environment variable.          |
-| `ntfy_priority`   | No       | Ntfy message priority.                                                        |
+| `ntfy_priority`   | No       | Ntfy message priority. Overrides default value and/or environment variable.   |

--- a/src/Config/Validate/Ntfy.php
+++ b/src/Config/Validate/Ntfy.php
@@ -33,7 +33,7 @@ class Ntfy extends AbstractValidator
                 throw new ConfigException('Ntfy priority value is not a number [VIGILANT_NOTIFICATION_NTFY_TOPIC]');
             }
 
-            $this->config['notification_ntfy_priority'] = $this->getEnv('NOTIFICATION_NTFY_TOPIC');
+            $this->config['notification_ntfy_priority'] = (int) $this->getEnv('NOTIFICATION_NTFY_PRIORITY');
         }
     }
 

--- a/src/Config/Validate/Ntfy.php
+++ b/src/Config/Validate/Ntfy.php
@@ -22,6 +22,22 @@ class Ntfy extends AbstractValidator
     }
 
     /**
+     * Validate `VIGILANT_NOTIFICATION_NTFY_PRIORITY`
+     *
+     * @throws ConfigException if priority is not a number
+     */
+    public function priority(): void
+    {
+        if ($this->hasEnv('NOTIFICATION_NTFY_PRIORITY') === true) {
+            if (is_numeric($this->getEnv('NOTIFICATION_NTFY_PRIORITY')) === false) {
+                throw new ConfigException('Ntfy priority value is not a number [VIGILANT_NOTIFICATION_NTFY_TOPIC]');
+            }
+
+            $this->config['notification_ntfy_priority'] = $this->getEnv('NOTIFICATION_NTFY_TOPIC');
+        }
+    }
+
+    /**
      * Validate `VIGILANT_NOTIFICATION_NTFY_TOPIC`
      *
      * @throws ConfigException if no ntfy topic is given

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -127,6 +127,7 @@ class Validator extends AbstractValidator
             $ntfy = new Validate\Ntfy($this->config);
             $ntfy->url();
             $ntfy->topic();
+            $ntfy->priority();
             $ntfy->auth();
             $this->config = $ntfy->getConfig();
         }

--- a/tests/Config/Validate/NtfyTest.php
+++ b/tests/Config/Validate/NtfyTest.php
@@ -50,6 +50,34 @@ class NtfyTest extends \TestCase
     }
 
     /**
+     * Test priority
+     */
+    public function testPriority(): void
+    {
+        putenv('VIGILANT_NOTIFICATION_NTFY_PRIORITY=1');
+
+        $validate = new Validate(self::$defaults);
+        $validate->priority();
+        $config = $validate->getConfig();
+
+        $this->assertEquals(1, $config['notification_ntfy_priority']);
+    }
+
+    /**
+     * Test priority is not a number
+     */
+    public function testPriorityNotNumber(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Ntfy priority value is not a number');
+
+        putenv('VIGILANT_NOTIFICATION_NTFY_PRIORITY=hello');
+
+        $validate = new Validate(self::$defaults);
+        $validate->priority();
+    }
+
+    /**
      * Test topic
      */
     public function testTopic(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,6 +46,7 @@ abstract class TestCase extends BaseTestCase
 
         // Ntfy
         putenv('VIGILANT_NOTIFICATION_NTFY_URL');
+        putenv('VIGILANT_NOTIFICATION_NTFY_PRIORITY');
         putenv('VIGILANT_NOTIFICATION_NTFY_TOPIC');
         putenv('VIGILANT_NOTIFICATION_NTFY_AUTH');
         putenv('VIGILANT_NOTIFICATION_NTFY_TOKEN');


### PR DESCRIPTION
Adds environment variable `VIGILANT_NOTIFICATION_NTFY_PRIORITY` to control Ntfy message priority. 

https://docs.ntfy.sh/publish/#message-priority