### PR TITLE
Add Gotify priority environment variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,10 +32,11 @@ To send push notifications, a notification service is required. Vigilant support
 
 To use Gotify, a URL and application token must be given.
 
-| Name                                 | Description                |
-| ------------------------------------ | -------------------------- |
-| `VIGILANT_NOTIFICATION_GOTIFY_URL`   | URL used to access Gotify. |
-| `VIGILANT_NOTIFICATION_GOTIFY_TOKEN` | Gotify application token.  |
+| Name                                    | Description                             |
+| --------------------------------------- | --------------------------------------- |
+| `VIGILANT_NOTIFICATION_GOTIFY_URL`      | URL used to access Gotify.              |
+| `VIGILANT_NOTIFICATION_GOTIFY_TOKEN`    | Gotify application token.               |
+| `VIGILANT_NOTIFICATION_GOTIFY_PRIORITY` | Gotify message priority. Defaults to 4. |
 
 ### Ntfy
 

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -26,7 +26,7 @@ feeds:
 | `url`             | **Yes**  | Feed URL                                                                      |
 | `interval`        | **Yes**  | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).  |
 | `gotify_token`    | No       | Gotify application token. Overrides token set with an environment variable.   |
-| `gotify_priority` | No       | Gotify message priority.                                                      |
+| `gotify_priority` | No       | Gotify message priority. Overrides default value and/or environment variable. |
 | `ntfy_topic`      | No       | Ntfy topic. Overrides topic set with an environment variable.                 |
 | `ntfy_token`      | No       | Ntfy access token. Overrides token set with an environment variable.          |
 | `ntfy_priority`   | No       | Ntfy message priority. Overrides default value and/or environment variable.   |

--- a/src/Config/Validate/Gotify.php
+++ b/src/Config/Validate/Gotify.php
@@ -30,7 +30,9 @@ class Gotify extends AbstractValidator
     {
         if ($this->hasEnv('NOTIFICATION_GOTIFY_PRIORITY') === true) {
             if (is_numeric($this->getEnv('NOTIFICATION_GOTIFY_PRIORITY')) === false) {
-                throw new ConfigException('Gotify priority value is not a number [VIGILANT_NOTIFICATION_GOTIFY_PRIORITY]');
+                throw new ConfigException(
+                    'Gotify priority value is not a number [VIGILANT_NOTIFICATION_GOTIFY_PRIORITY]'
+                );
             }
 
             $this->config['notification_gotify_priority'] = (int) $this->getEnv('NOTIFICATION_GOTIFY_PRIORITY');

--- a/src/Config/Validate/Gotify.php
+++ b/src/Config/Validate/Gotify.php
@@ -22,6 +22,22 @@ class Gotify extends AbstractValidator
     }
 
     /**
+     * Validate `VIGILANT_NOTIFICATION_GOTIFY_PRIORITY`
+     *
+     * @throws ConfigException if priority is not a number
+     */
+    public function priority(): void
+    {
+        if ($this->hasEnv('NOTIFICATION_GOTIFY_PRIORITY') === true) {
+            if (is_numeric($this->getEnv('NOTIFICATION_GOTIFY_PRIORITY')) === false) {
+                throw new ConfigException('Gotify priority value is not a number [VIGILANT_NOTIFICATION_GOTIFY_PRIORITY]');
+            }
+
+            $this->config['notification_gotify_priority'] = (int) $this->getEnv('NOTIFICATION_GOTIFY_PRIORITY');
+        }
+    }
+
+    /**
      * Validate `VIGILANT_NOTIFICATION_GOTIFY_TOKEN`
      *
      * @throws ConfigException if no auth token is given

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -117,10 +117,11 @@ class Validator extends AbstractValidator
         $this->config['notification_service'] = $service;
 
         if ($service === 'gotify') {
-            $ntfy = new Validate\Gotify($this->config);
-            $ntfy->url();
-            $ntfy->token();
-            $this->config = $ntfy->getConfig();
+            $gotify = new Validate\Gotify($this->config);
+            $gotify->url();
+            $gotify->priority();
+            $gotify->token();
+            $this->config = $gotify->getConfig();
         }
 
         if ($service === 'ntfy') {

--- a/tests/Config/Validate/GotifyTest.php
+++ b/tests/Config/Validate/GotifyTest.php
@@ -50,6 +50,34 @@ class GotifyTest extends \TestCase
     }
 
     /**
+     * Test priority
+     */
+    public function testPriority(): void
+    {
+        putenv('VIGILANT_NOTIFICATION_GOTIFY_PRIORITY=1');
+
+        $validate = new Validate(self::$defaults);
+        $validate->priority();
+        $config = $validate->getConfig();
+
+        $this->assertEquals(1, $config['notification_gotify_priority']);
+    }
+
+    /**
+     * Test priority is not a number
+     */
+    public function testPriorityNotNumber(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Gotify priority value is not a number');
+
+        putenv('VIGILANT_NOTIFICATION_GOTIFY_PRIORITY=hello');
+
+        $validate = new Validate(self::$defaults);
+        $validate->priority();
+    }
+
+    /**
      * Test token
      */
     public function testToken(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,6 +43,7 @@ abstract class TestCase extends BaseTestCase
         // Gotify
         putenv('VIGILANT_NOTIFICATION_GOTIFY_URL');
         putenv('VIGILANT_NOTIFICATION_GOTIFY_TOKEN');
+        putenv('VIGILANT_NOTIFICATION_GOTIFY_PRIORITY');
 
         // Ntfy
         putenv('VIGILANT_NOTIFICATION_NTFY_URL');


### PR DESCRIPTION
Adds environment variable `VIGILANT_NOTIFICATION_GOTIFY_PRIORITY` to control Gotify message priority. 