### PR TITLE
Fix fatal error when calling Config method `getNtfyAuthMethod()`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -29,6 +29,7 @@ class Config
         'feeds_file' => 'feeds.yaml',
         'notification_gotify_priority' => 4,
         'notification_ntfy_priority' => 3,
+        'notification_ntfy_auth' => 'none'
     ];
 
     /** @var array<string, mixed> $config Loaded config parameters */

--- a/src/Notify.php
+++ b/src/Notify.php
@@ -96,8 +96,10 @@ class Notify
         ];
 
         if ($this->config->getNtfyAuthMethod() === 'password') {
-            $ntfyConfig['auth']['username'] = $this->config->getNtfyUsername();
-            $ntfyConfig['auth']['password'] = $this->config->getNtfyPassword();
+            $ntfyConfig['auth'] = [
+                'username' => $this->config->getNtfyUsername(),
+                'password' => $this->config->getNtfyPassword()
+            ];
         } elseif ($this->config->getNtfyAuthMethod() === 'token') {
             $ntfyConfig['auth']['token'] = $this->config->getNtfyToken();
         }

--- a/src/Notify.php
+++ b/src/Notify.php
@@ -96,10 +96,8 @@ class Notify
         ];
 
         if ($this->config->getNtfyAuthMethod() === 'password') {
-            $ntfyConfig['auth'] = [
-                'username' => $this->config->getNtfyUsername(),
-                'password' => $this->config->getNtfyPassword()
-            ];
+            $ntfyConfig['auth']['username'] = $this->config->getNtfyUsername();
+            $ntfyConfig['auth']['password'] = $this->config->getNtfyPassword();
         } elseif ($this->config->getNtfyAuthMethod() === 'token') {
             $ntfyConfig['auth']['token'] = $this->config->getNtfyToken();
         }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -129,13 +129,7 @@ class ConfigTest extends TestCase
     public function testGetNtfyAuthMethod(): void
     {
         $config = new Config();
-
-        $reflection = new ReflectionClass($config);
-        $property = $reflection->getProperty('config');
-        $property->setAccessible(true);
-        $property->setValue($config, ['notification_ntfy_auth' => 'password']);
-
-        $this->assertEquals('password', $config->getNtfyAuthMethod());
+        $this->assertEquals('none', $config->getNtfyAuthMethod());
     }
 
     /**


### PR DESCRIPTION
Fix fatal error when calling Config method `getNtfyAuthMethod()` if no Ntfy auth method is set.