### PR TITLE
Add feeds file option for notification title prefixes

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -24,7 +24,7 @@ feeds:
 | `name`            | **Yes**  | Feed name                                                                     |
 | `url`             | **Yes**  | Feed URL                                                                      |
 | `interval`        | **Yes**  | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).  |
-| `title_prefix`    | No       | Text to prepend to the title of a message.                                    |
+| `title_prefix`    | No       | Text to prepend to notification titles.                                       |
 | `gotify_token`    | No       | Gotify application token. Overrides token set with an environment variable.   |
 | `gotify_priority` | No       | Gotify message priority. Overrides default value and/or environment variable. |
 | `ntfy_topic`      | No       | Ntfy topic. Overrides topic set with an environment variable.                 |

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -24,6 +24,7 @@ feeds:
 | `name`            | **Yes**  | Feed name                                                                     |
 | `url`             | **Yes**  | Feed URL                                                                      |
 | `interval`        | **Yes**  | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).  |
+| `title_prefix`    | No       | Text to append to the front of a message's title.                             |
 | `gotify_token`    | No       | Gotify application token. Overrides token set with an environment variable.   |
 | `gotify_priority` | No       | Gotify message priority. Overrides default value and/or environment variable. |
 | `ntfy_topic`      | No       | Ntfy topic. Overrides topic set with an environment variable.                 |

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -24,7 +24,7 @@ feeds:
 | `name`            | **Yes**  | Feed name                                                                     |
 | `url`             | **Yes**  | Feed URL                                                                      |
 | `interval`        | **Yes**  | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).  |
-| `title_prefix`    | No       | Text to append to the front of a message's title.                             |
+| `title_prefix`    | No       | Text to prepend to the title of a message.                                    |
 | `gotify_token`    | No       | Gotify application token. Overrides token set with an environment variable.   |
 | `gotify_priority` | No       | Gotify message priority. Overrides default value and/or environment variable. |
 | `ntfy_topic`      | No       | Ntfy topic. Overrides topic set with an environment variable.                 |

--- a/src/Check.php
+++ b/src/Check.php
@@ -145,9 +145,10 @@ final class Check
 
                 if ($this->cache->isFirstCheck() === false) {
                     $this->messages[] = new Message(
-                        title: $title,
-                        body: $body,
-                        url: $item->getLink()
+                        $title,
+                        $body,
+                        $item->getLink(),
+                        $this->details->getTitlePrefix()
                     );
                 }
             }

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -60,6 +60,16 @@ final class Details
     }
 
     /**
+     * Get title prefix
+     *
+     * @return ?string
+     */
+    public function getTitlePrefix(): ?string
+    {
+        return $this->details['title_prefix'] ?? null;
+    }
+
+    /**
      * Get gotify applications token
      *
      * @return ?string

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -24,6 +24,7 @@ final class Validate
         $this->name();
         $this->url();
         $this->interval($minCheckInterval);
+        $this->titlePrefix();
 
         $this->gotifyToken();
         $this->gotifyPriority();
@@ -69,6 +70,16 @@ final class Validate
                 'Interval is less than ' . $minCheckInterval .
                 ' seconds for feed: ' . $this->details['name']
             );
+        }
+    }
+
+    /**
+     * Validate entry title prefix
+     */
+    private function titlePrefix(): void
+    {
+        if (array_key_exists('title_prefix', $this->details) === true && $this->details['title_prefix'] === null) {
+            throw new FeedsException('Empty title prefix given for feed: ' . $this->details['name']);
         }
     }
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -4,6 +4,7 @@ namespace Vigilant;
 
 class Message
 {
+    private ?string $prefix = null;
     private string $title;
     private string $body;
     private string $url;
@@ -12,12 +13,14 @@ class Message
      * @param string $title Message title
      * @param string $body Message body
      * @param string $url Message URL
+     * @param ?string $prefix Message title prefix
      */
-    public function __construct(string $title, string $body, string $url = '')
+    public function __construct(string $title, string $body, string $url = '', ?string $prefix = null)
     {
         $this->title = $title;
         $this->body = $body;
         $this->url = $url;
+        $this->prefix = $prefix;
     }
 
     /**
@@ -26,6 +29,14 @@ class Message
      */
     public function getTitle(): string
     {
+        if ($this->prefix !== null) {
+            return sprintf(
+                '%s %s',
+                trim($this->prefix),
+                $this->title
+            );
+        }
+
         return $this->title;
     }
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -33,7 +33,7 @@ class Message
             return sprintf(
                 '%s %s',
                 trim($this->prefix),
-                $this->title
+                trim($this->title)
             );
         }
 

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -72,6 +72,19 @@ class DetailsTest extends TestCase
     }
 
     /**
+     * Test getTitlePrefix()
+     */
+    public function testGetTitlePrefix(): void
+    {
+        $details = new Details(self::$feeds[0]);
+
+        $this->assertEquals(
+            self::$feeds[0]['title_prefix'],
+            $details->getTitlePrefix()
+        );
+    }
+
+    /**
      * Test getGotifyToken()
      */
     public function testGetGotifyToken(): void

--- a/tests/Feed/ValidateTest.php
+++ b/tests/Feed/ValidateTest.php
@@ -27,9 +27,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with valid feed entry
+     * Test valid feed entry
      */
-    public function testValidateWithValidEntry(): void
+    public function testValidEntry(): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -39,9 +39,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry missing a name value
+     * Test feed entry missing a name value
      */
-    public function testValidateWithNoNameEntry(): void
+    public function testNoNameEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('No name given');
@@ -50,9 +50,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty name value
+     * Test feed entry with an empty name value
      */
-    public function testValidateWithEmptyNameEntry(): void
+    public function testEmptyNameEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('No name given');
@@ -61,9 +61,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry missing a URL value
+     * Test feed entry missing a URL value
      */
-    public function testValidateWithNoUrlEntry(): void
+    public function testNoUrlEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('No url given');
@@ -72,9 +72,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty URL value
+     * Test feed entry with an empty URL value
      */
-    public function testValidateWithEmptyUrlEntry(): void
+    public function testEmptyUrlEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('No url given');
@@ -83,9 +83,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry missing an interval value
+     * Test feed entry missing an interval value
      */
-    public function testValidateWithNoIntervalEntry(): void
+    public function testNoIntervalEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('No interval given');
@@ -94,9 +94,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty interval value
+     * Test feed entry with an empty interval value
      */
-    public function testValidateWithEmptyIntervalEntry(): void
+    public function testEmptyIntervalEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('No interval given');
@@ -105,9 +105,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an interval value lower than minimum allowed
+     * Test feed entry with interval value lower than minimum allowed
      */
-    public function testValidateWithIntervalEntryLowerThanMin(): void
+    public function testIntervalEntryLowerThanMin(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('Interval is less than 300 seconds for feed');
@@ -116,9 +116,20 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty gotify token value
+     * Test feed entry with an empty title prefix value
      */
-    public function testValidateWithEmptyGotifyTokenEntry(): void
+    public function testEmptyTitlePrefixEntry(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('Empty title prefix given');
+
+        new Validate(self::$feedsInvalid['emptyTitlePrefix'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with an empty gotify token value
+     */
+    public function testEmptyGotifyTokenEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('Empty Gotify token given');
@@ -127,9 +138,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty gotify priority value
+     * Test feed entry with an empty gotify priority value
      */
-    public function testValidateWithEmptyGotifyPriorityEntry(): void
+    public function testEmptyGotifyPriorityEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('Empty Gotify priority given');
@@ -138,9 +149,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty ntfy topic value
+     * Test feed entry with an empty ntfy topic value
      */
-    public function testValidateWithEmptyNtfyTopicEntry(): void
+    public function testEmptyNtfyTopicEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('Empty Ntfy topic given');
@@ -149,9 +160,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty ntfy priority value
+     * Test feed entry with an empty ntfy priority value
      */
-    public function testValidateWithEmptyNtfyPriorityEntry(): void
+    public function testEmptyNtfyPriorityEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('Empty Ntfy priority given');
@@ -160,9 +171,9 @@ class ValidateTest extends TestCase
     }
 
     /**
-     * Test validator with feed entry with an empty ntfy token value
+     * Test feed entry with an empty ntfy token value
      */
-    public function testValidateWithEmptyNtfyTokenEntry(): void
+    public function testEmptyNtfyTokenEntry(): void
     {
         $this->expectException(FeedsException::class);
         $this->expectExceptionMessage('Empty Ntfy token given');

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -34,7 +34,5 @@ class MessageTest extends TestCase
         $message = new Message($title, $body, $url, $prefix);
 
         $this->assertEquals($fullTitle, $message->getTitle());
-        $this->assertEquals($body, $message->getBody());
-        $this->assertEquals($url, $message->getUrl());
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -18,4 +18,23 @@ class MessageTest extends TestCase
         $this->assertEquals($body, $message->getBody());
         $this->assertEquals($url, $message->getUrl());
     }
+
+    /**
+     * Test Message class with title prefix
+     */
+    public function testTitlePrefix(): void
+    {
+        $title = 'Hello World';
+        $body = 'Hello World from phpunit';
+        $url = 'https://example.com/';
+        $prefix = 'testing!';
+
+        $fullTitle = $prefix . ' ' . $title;
+
+        $message = new Message($title, $body, $url, $prefix);
+
+        $this->assertEquals($fullTitle, $message->getTitle());
+        $this->assertEquals($body, $message->getBody());
+        $this->assertEquals($url, $message->getUrl());
+    }
 }

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -31,6 +31,12 @@ feeds:
     url: https://www.example.com/feed.rss
     interval: 100
 
+  emptyTitlePrefix:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    title_prefix:
+
   emptyGotifyToken:
     name: Example.com Feed
     url: https://www.example.com/feed.rss

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -3,6 +3,7 @@ feeds:
      name: Met Office weather warnings
      url: http://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/UK
      interval: 900
+     title_prefix: Weather Alert!
      gotify_token: 7ZHeHM3awd45rn9W
      gotify_priority: 1
     -


### PR DESCRIPTION
Adds feed file option for prepending text to notification titles.

```YAML
- name: Example feed
  url: https://example.com/feed.rss
  interval: 600
  ntfy_topic: test
  title_prefix: Status change!
```

![image](https://github.com/VerifiedJoseph/vigilant/assets/20118140/6ac56c4f-dcc4-4883-a55e-92f9c5bcf914)
