### PR TITLE
Add support for active hours

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -1,10 +1,8 @@
 # Feeds File
 
-A YAML file named `feeds.yaml` is used to configure the RSS, ATOM and JSON feeds that Vigilant should monitor.
+A YAML file named `feeds.yaml` is used to configure the RSS, ATOM and JSON feeds that Vigilant should monitor. An [example file](../feeds.example.yaml) is available.
 
 By default Vigilant looks for a `feeds.yaml` file in the project's main folder, this behavior can be overridden with an [environment variable](configuration.md#feeds-file).
-
-An [example file](../feeds.example.yaml) is available.
 
 Each entry in the YAML file must have a name, URL and interval parameter. All other parameters are optional.
 
@@ -17,7 +15,14 @@ feeds:
     - name: GitHub Status
       url: https://www.githubstatus.com/history.rss
       interval: 600
+      active_hours:
+        start_time: '09:30'
+        end_time: '17:00'
 ```
+
+## Parameters
+
+### Standard
 
 | Name              | Required | Description                                                                   |
 | ----------------- | -------- | ----------------------------------------------------------------------------- |
@@ -25,8 +30,29 @@ feeds:
 | `url`             | **Yes**  | Feed URL                                                                      |
 | `interval`        | **Yes**  | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).  |
 | `title_prefix`    | No       | Text to prepend to notification titles.                                       |
+
+### Notification services
+
+| Name              | Required | Description                                                                   |
+| ----------------- | -------- | ----------------------------------------------------------------------------- |
 | `gotify_token`    | No       | Gotify application token. Overrides token set with an environment variable.   |
 | `gotify_priority` | No       | Gotify message priority. Overrides default value and/or environment variable. |
 | `ntfy_topic`      | No       | Ntfy topic. Overrides topic set with an environment variable.                 |
 | `ntfy_token`      | No       | Ntfy access token. Overrides token set with an environment variable.          |
 | `ntfy_priority`   | No       | Ntfy message priority. Overrides default value and/or environment variable.   |
+
+### Active hours
+
+Use to restrict feed monitoring to a specific window of time.
+
+Both parameters are required when configuring an active hours window.
+
+| Name                     | Description                                                         |
+| ------------------------ | ------------------------------------------------------------------- |
+| `active_hours.start_time`| Start time for active hours window in 24-hour format. e.g: `09:00`  |
+| `active_hours.end_time`  | End time for active hours window in 24-hour format. e.g: `16:30`    |
+
+#### Limitations
+
+- The active hours window must start and end on the same day.
+- Only 24-hour time formats are supported.

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -43,14 +43,14 @@ feeds:
 
 ### Active hours
 
-Use to restrict feed monitoring to a specific window of time.
+Use active hours to restrict feed monitoring to a specific window of time.
 
 Both parameters are required when configuring an active hours window.
 
-| Name                     | Description                                                         |
-| ------------------------ | ------------------------------------------------------------------- |
-| `active_hours.start_time`| Start time for active hours window in 24-hour format. e.g: `09:00`  |
-| `active_hours.end_time`  | End time for active hours window in 24-hour format. e.g: `16:30`    |
+| Name                     | Description                                                  |
+| ------------------------ | ------------------------------------------------------------ |
+| `active_hours.start_time`| Start time for active hours in 24-hour format. e.g: `09:00`  |
+| `active_hours.end_time`  | End time for active hours in 24-hour format. e.g: `16:30`    |
 
 #### Limitations
 

--- a/feeds.example.yaml
+++ b/feeds.example.yaml
@@ -2,3 +2,10 @@ feeds:
     - name: Met Office weather warnings
       url: http://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/UK
       interval: 1900
+
+    - name: GitHub status
+      url: https://www.githubstatus.com/history.rss
+      interval: 600
+      active_hours:
+        start_time: 09:30
+        end_time: 17:00

--- a/src/ActiveHours.php
+++ b/src/ActiveHours.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Vigilant;
+
+use DateTime;
+use DateTimeZone;
+
+class ActiveHours
+{
+    private Logger $logger;
+
+    private DateTime $now;
+    private DateTime $start;
+    private DateTime $end;
+
+    private DateTimeZone $timezone;
+    private bool $enabled = false;
+
+    private string $format = 'Y-m-d H:i:s e';
+
+    /**
+     * @param DateTime $now Current time and date
+     * @param ?string $startTime Start time
+     * @param ?string $endTime End time
+     * @param string $timezone Timezone
+     * @param Logger $logger
+     */
+    public function __construct(DateTime $now, ?string $startTime, ?string $endTime, string $timezone, Logger $logger)
+    {
+        $this->logger = $logger;
+
+        $this->now = $now;
+        $this->timezone = new DateTimeZone($timezone);
+
+        $this->process($startTime, $endTime);
+    }
+
+    /**
+     * Returns boolean indicating if time is in active hours window
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Returns start time as a readable string
+     * @return string
+     */
+    public function getStartTime(): string
+    {
+        return $this->start->format($this->format);
+    }
+
+    /**
+     * Returns end time as a readable string
+     * @return string
+     */
+    public function getEndTime(): string
+    {
+        return $this->end->format($this->format);
+    }
+
+    /**
+     * @param ?string $startTime Start time
+     * @param ?string $endTime End time
+     */
+    private function process(?string $startTime, ?string $endTime): void
+    {
+        if ($startTime !== null && $endTime !== null) {
+            $this->start = new DateTime($startTime, $this->timezone);
+            $this->end = new DateTime($endTime, $this->timezone);
+            
+            if ($this->now >= $this->start && $this->now <= $this->end) {
+                $this->enabled = true;
+            }
+
+            $this->logger->debug('Active hours details:');
+            $this->logger->debug('Current time: ' . $this->now->format('Y-m-d H:i:s e'));
+            $this->logger->debug('Start time:   ' . $this->start->format('Y-m-d H:i:s e'));
+            $this->logger->debug('End time:     ' . $this->end->format('Y-m-d H:i:s e'));
+            $this->logger->debug('Enabled: ' . ($this->enabled ? 'true' : 'false'));
+        }
+    }
+}

--- a/src/ActiveHours.php
+++ b/src/ActiveHours.php
@@ -71,7 +71,7 @@ class ActiveHours
         if ($startTime !== null && $endTime !== null) {
             $this->start = new DateTime($startTime, $this->timezone);
             $this->end = new DateTime($endTime, $this->timezone);
-            
+
             if ($this->now >= $this->start && $this->now <= $this->end) {
                 $this->enabled = true;
             }

--- a/src/ActiveHours.php
+++ b/src/ActiveHours.php
@@ -16,8 +16,6 @@ class ActiveHours
     private DateTimeZone $timezone;
     private bool $enabled = false;
 
-    private string $format = 'Y-m-d H:i:s e';
-
     /**
      * @param DateTime $now Current time and date
      * @param ?string $startTime Start time
@@ -45,21 +43,23 @@ class ActiveHours
     }
 
     /**
-     * Returns start time as a readable string
+     * Returns start time
+     * @param string $format Format accepted by date()
      * @return string
      */
-    public function getStartTime(): string
+    public function getStartTime(string $format = 'Y-m-d H:i:s e'): string
     {
-        return $this->start->format($this->format);
+        return $this->start->format($format);
     }
 
     /**
-     * Returns end time as a readable string
+     * Returns end time
+     * @param string $format Format accepted by date()
      * @return string
      */
-    public function getEndTime(): string
+    public function getEndTime(string $format = 'Y-m-d H:i:s e'): string
     {
-        return $this->end->format($this->format);
+        return $this->end->format($format);
     }
 
     /**

--- a/src/Check.php
+++ b/src/Check.php
@@ -68,16 +68,17 @@ final class Check
     }
 
     /**
-     * Returns next check date in readable format (`Y-m-d H:i:s`)
+     * Returns next check date
+     * @param string $format Format accepted by date()
      * @return string
      */
-    public function getNextCheckDate(): string
+    public function getNextCheckDate(string $format = 'Y-m-d H:i:s'): string
     {
         $date = new DateTime();
         $date->setTimestamp($this->cache->getNextCheck());
         $date->setTimezone(new DateTimeZone($this->config->getTimezone()));
 
-        return $date->format('Y-m-d H:i:s');
+        return $date->format($format);
     }
 
     public function check(): void

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -4,9 +4,7 @@ namespace Vigilant\Feed;
 
 final class Details
 {
-    /**
-     * @var array<string, mixed> $details Feed details from feeds.yaml
-     */
+    /** @var array<string, mixed> $details Feed details from feeds.yaml */
     private array $details = [];
 
     /**

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -10,8 +10,6 @@ final class Details
     private array $details = [];
 
     /**
-     * Constructor
-     *
      * @param array<string, mixed> $feed
      */
     public function __construct(array $feed)
@@ -137,6 +135,19 @@ final class Details
     public function getActiveHoursEndTime(): ?string
     {
         return $this->details['active_hours']['end_time'] ?? null;
+    }
+
+    /**
+     * Returns boolean indicating if active hours are configured for the feed
+     * @return bool
+     */
+    public function hasActiveHours(): bool
+    {
+        if ($this->getActiveHoursStartTime() !== null && $this->getActiveHoursEndTime() !== null) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -120,7 +120,27 @@ final class Details
     }
 
     /**
-     * Has entry got a ntfy token
+     * Returns active hours start time
+     *
+     * @return ?string
+     */
+    public function getActiveHoursStartTime(): ?string
+    {
+        return $this->details['active_hours']['start_time'] ?? null;
+    }
+
+    /**
+     * Returns active hours end time
+     *
+     * @return ?string
+     */
+    public function getActiveHoursEndTime(): ?string
+    {
+        return $this->details['active_hours']['end_time'] ?? null;
+    }
+
+    /**
+     * Check if entry has a ntfy token parameter
      *
      * @return bool
      */
@@ -130,7 +150,7 @@ final class Details
     }
 
     /**
-     * Has entry got a ntfy topic
+     * Check if entry has a ntfy topic parameter
      *
      * @return bool
      */
@@ -140,7 +160,7 @@ final class Details
     }
 
     /**
-     * Has entry got a ntfy priority
+     * Check if entry has a ntfy priority parameter
      *
      * @return bool
      */
@@ -150,7 +170,7 @@ final class Details
     }
 
     /**
-     * Has entry got Gotify token
+     * Check if entry has a Gotify token parameter
      *
      * @return bool
      */
@@ -160,7 +180,7 @@ final class Details
     }
 
     /**
-     * Has entry got Gotify priority
+     * Check if entry has a Gotify priority parameter
      *
      * @return bool
      */
@@ -170,7 +190,7 @@ final class Details
     }
 
     /**
-     * Has entry got a value
+     * heck if entry has a parameter
      *
      * @return bool
      */

--- a/src/Feed/Feed.php
+++ b/src/Feed/Feed.php
@@ -14,34 +14,22 @@ use Vigilant\Feed\Details;
 
 final class Feed
 {
-    /**
-     * @var Details
-     */
+    /** @var Details Feed details class instance */
     public Details $details;
 
-    /**
-     * @var ActiveHours
-     */
+    /** @var ActiveHours ActiveHours class instance */
     public ActiveHours $activeHours;
 
-    /**
-     * @var Check
-     */
+    /** @var Check Check class instance */
     public Check $check;
 
-    /**
-     * @var Config
-     */
+    /** @var Config Config class instance */
     private Config $config;
 
-    /**
-     * @var Logger
-     */
+    /** @var Logger Logger class instance */
     private Logger $logger;
 
-    /**
-     * @var array<string, mixed> $feed Feed entry from feeds.yaml
-     */
+    /** @var array<string, mixed> $feed Feed entry from feeds.yaml */
     private array $feed = [];
 
     /**

--- a/src/Feed/Feed.php
+++ b/src/Feed/Feed.php
@@ -2,16 +2,42 @@
 
 namespace Vigilant\Feed;
 
+use DateTime;
+use DateTimeZone;
+use Vigilant\Check;
+use Vigilant\Fetch;
+use Vigilant\ActiveHours;
 use Vigilant\Config;
+use Vigilant\Logger;
 use Vigilant\Feed\Validate;
 use Vigilant\Feed\Details;
 
 final class Feed
 {
     /**
+     * @var Details
+     */
+    public Details $details;
+
+    /**
+     * @var ActiveHours
+     */
+    public ActiveHours $activeHours;
+
+    /**
+     * @var Check
+     */
+    public Check $check;
+
+    /**
      * @var Config
      */
     private Config $config;
+
+    /**
+     * @var Logger
+     */
+    private Logger $logger;
 
     /**
      * @var array<string, mixed> $feed Feed entry from feeds.yaml
@@ -19,27 +45,18 @@ final class Feed
     private array $feed = [];
 
     /**
-     * Constructor
-     *
      * @param array<string, mixed> $feed
      * @param Config $config
+     * @param Logger $logger
      */
-    public function __construct(array $feed, Config $config)
+    public function __construct(array $feed, Config $config, Logger $logger)
     {
         $this->feed = $feed;
         $this->config = $config;
+        $this->logger = $logger;
 
         $this->validate();
-    }
-
-    /**
-     * Get details for feed entry
-     *
-     * @return Details
-     */
-    public function getDetails(): Details
-    {
-        return new Details($this->feed);
+        $this->initiate();
     }
 
     /**
@@ -50,6 +67,30 @@ final class Feed
         new Validate(
             $this->feed,
             $this->config->getMinCheckInterval()
+        );
+    }
+
+    private function initiate(): void
+    {
+        $this->details = new Details($this->feed);
+        $this->check = new Check(
+            $this->details,
+            new Fetch(),
+            $this->config,
+            $this->logger
+        );
+
+        $now = new DateTime(
+            'now',
+            new DateTimeZone($this->config->getTimezone())
+        );
+
+        $this->activeHours = new ActiveHours(
+            $now,
+            $this->details->getActiveHoursStartTime(),
+            $this->details->getActiveHoursEndTime(),
+            $this->config->getTimezone(),
+            $this->logger
         );
     }
 }

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -168,7 +168,7 @@ final class Validate
      * @throws FeedsException if no end time is given  or is empty
      * @throws FeedsException if start time format is invalid
      * @throws FeedsException if end time format is invalid
-     * @throws FeedsException if end time is before the start emd 
+     * @throws FeedsException if end time is before the start emd
      */
     private function activeHours(): void
     {

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -2,6 +2,7 @@
 
 namespace Vigilant\Feed;
 
+use Vigilant\Helper\Time;
 use Vigilant\Exception\FeedsException;
 
 final class Validate
@@ -32,10 +33,14 @@ final class Validate
         $this->ntfyTopic();
         $this->ntfyToken();
         $this->ntfyPriority();
+
+        $this->activeHours();
     }
 
     /**
      * Validate entry name
+     *
+     * @throws FeedsException if name is not given
      */
     private function name(): void
     {
@@ -46,6 +51,8 @@ final class Validate
 
     /**
      * Validate entry URL
+     *
+     * @throws FeedsException if url is not given
      */
     private function url(): void
     {
@@ -58,6 +65,8 @@ final class Validate
      * Validate entry interval
      *
      * @param int $minCheckInterval Minimum feed check interval
+     * @throws FeedsException if interval is not given
+     * @throws FeedsException if interval is less than minimum allowed interval
      */
     private function interval(int $minCheckInterval): void
     {
@@ -75,6 +84,8 @@ final class Validate
 
     /**
      * Validate entry title prefix
+     *
+     * @throws FeedsException if title prefix is empty
      */
     private function titlePrefix(): void
     {
@@ -85,6 +96,8 @@ final class Validate
 
     /**
      * Validate entry gotify token
+     *
+     * @throws FeedsException if gotify token is empty
      */
     private function gotifyToken(): void
     {
@@ -95,6 +108,8 @@ final class Validate
 
     /**
      * Validate entry gotify priority
+     *
+     * @throws FeedsException if gotify priority is empty
      */
     private function gotifyPriority(): void
     {
@@ -108,6 +123,8 @@ final class Validate
 
     /**
      * Validate entry ntfy topic
+     *
+     * @throws FeedsException if ntfy topic is empty
      */
     private function ntfyTopic(): void
     {
@@ -118,6 +135,8 @@ final class Validate
 
     /**
      * Validate entry gotify token
+     *
+     * @throws FeedsException if ntfy token is empty
      */
     private function ntfyToken(): void
     {
@@ -128,6 +147,8 @@ final class Validate
 
     /**
      * Validate entry ntfy priority
+     *
+     * @throws FeedsException if ntfy priority is empty
      */
     private function ntfyPriority(): void
     {
@@ -136,6 +157,47 @@ final class Validate
              $this->details['ntfy_priority'] === null
         ) {
             throw new FeedsException('Empty Ntfy priority given for feed: ' . $this->details['name']);
+        }
+    }
+
+    /**
+     * Validate active hours options in entries
+     * 
+     * @throws FeedsException if no start time is given or is empty
+     * @throws FeedsException if no end time is given  or is empty
+     * @throws FeedsException if start time format is invalid
+     * @throws FeedsException if end time format is invalid
+     */
+    private function activeHours(): void
+    {
+        if (array_key_exists('active_hours', $this->details) === true) {
+            if ($this->details['active_hours'] === null) {
+                throw new FeedsException('Required active hours options not given for feed: ' . $this->details['name']);
+            }
+
+            if (array_key_exists('start_time', $this->details['active_hours']) === false) {
+                throw new FeedsException('No active hours start time given for feed: ' . $this->details['name']);
+            }
+
+            if (array_key_exists('end_time', $this->details['active_hours']) === false) {
+                throw new FeedsException('No active hours end time given for feed: ' . $this->details['name']);
+            }
+
+            if ($this->details['active_hours']['start_time'] === null) {
+                throw new FeedsException('Empty active hours start time given for feed: ' . $this->details['name']);
+            }
+
+            if ($this->details['active_hours']['end_time'] === null) {
+                throw new FeedsException('Empty active hours end time given for feed: ' . $this->details['name']);
+            }
+
+            if (Time::isValid($this->details['active_hours']['start_time']) === false) {
+                throw new FeedsException('Invalid active hours start time given for feed: ' . $this->details['name']);
+            }
+
+            if (Time::isValid($this->details['active_hours']['end_time']) === false) {
+                throw new FeedsException('Invalid active hours end time given for feed: ' . $this->details['name']);
+            }
         }
     }
 }

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -2,6 +2,7 @@
 
 namespace Vigilant\Feed;
 
+use DateTime;
 use Vigilant\Helper\Time;
 use Vigilant\Exception\FeedsException;
 
@@ -167,6 +168,7 @@ final class Validate
      * @throws FeedsException if no end time is given  or is empty
      * @throws FeedsException if start time format is invalid
      * @throws FeedsException if end time format is invalid
+     * @throws FeedsException if end time is before the start emd 
      */
     private function activeHours(): void
     {
@@ -197,6 +199,13 @@ final class Validate
 
             if (Time::isValid($this->details['active_hours']['end_time']) === false) {
                 throw new FeedsException('Invalid active hours end time given for feed: ' . $this->details['name']);
+            }
+
+            $start = new DateTime($this->details['active_hours']['start_time']);
+            $end = new DateTime($this->details['active_hours']['end_time']);
+
+            if ($end->getTimestamp() < $start->getTimestamp()) {
+                throw new FeedsException('Active hours end time is before the start time for ' . $this->details['name']);
             }
         }
     }

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -162,7 +162,7 @@ final class Validate
 
     /**
      * Validate active hours options in entries
-     * 
+     *
      * @throws FeedsException if no start time is given or is empty
      * @throws FeedsException if no end time is given  or is empty
      * @throws FeedsException if start time format is invalid

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -22,7 +22,7 @@ final class Feeds
     private Logger $logger;
 
     /**
-     * @var array<int, Details> $feeds Feed class for each feeds.yaml entry
+     * @var array<int, Feed> $feeds Feed class for each feeds.yaml entry
      */
     private array $feeds = [];
 
@@ -44,9 +44,9 @@ final class Feeds
     }
 
     /**
-     * Get details of each feed in the YAML file.
+     * Get Feed class of each feed in the YAML file.
      *
-     * @return array<int, Details>
+     * @return array<int, Feed>
      */
     public function get(): array
     {
@@ -87,8 +87,7 @@ final class Feeds
         }
 
         foreach ($feeds['feeds'] as $entry) {
-            $feed = new Feed($entry, $this->config);
-            $this->feeds[] = $feed->getDetails();
+            $this->feeds[] = new Feed($entry, $this->config, $this->logger);
         }
     }
 }

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -22,7 +22,7 @@ final class Feeds
     private Logger $logger;
 
     /**
-     * @var array<int, Details> $feeds Feed classes for each feeds.yaml entry
+     * @var array<int, Details> $feeds Feed class for each feeds.yaml entry
      */
     private array $feeds = [];
 

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Vigilant\Helper;
+
+use DateTime;
+
+class Time
+{
+    /**
+     * Supported time formats
+     * @var array<int, string>
+     */
+    private static array $timeFormats = [
+        'g a',   // 1 am  - 12-hour without leading zeros and lowercase am/pm
+        'G a',   // 01 am - 12-hour with leading zeros and lowercase am/pm
+        'ga',    // 1am   - 12-hour without leading zeros, lowercase am/pm and no space
+        'Ga',    // 01am  - 12-hour with leading zeros, lowercase am/pm and no space
+        'H',     // 05    - 24-hour with leading zeros
+        'H:i'    // 15:10 - 24-hour with leading zeros and minutes
+    ];
+
+    /**
+     * Check if a time format is valid
+     * @param string $time
+     * @return bool
+     */
+    public static function isValid(string $time): bool
+    {
+        $d = new DateTime();
+        $time = $d->format('Y-m-d ') . strtolower($time);
+
+        foreach(self::$timeFormats as $format) {
+            $date = DateTime::createFromFormat('Y-m-d ' . $format, $time);
+
+            if ($date !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -11,12 +11,10 @@ class Time
      * @var array<int, string>
      */
     private static array $timeFormats = [
-        'g a', // 1 am  - 12-hour without leading zeros and lowercase am/pm
-        'h a', // 01 am - 12-hour with leading zeros and lowercase am/pm
-        'ga',  // 1am   - 12-hour without leading zeros, lowercase am/pm and no space
-        'ha',  // 01am  - 12-hour with leading zeros, lowercase am/pm and no space
-        'H',   // 05    - 24-hour with leading zeros
-        'G',   // 15    - 24-hour without leading zeros
+        'H',   // 05    - 24-hour with leading zero
+        'G',   // 15    - 24-hour without leading zero
+        'H:i', // 05:10 - 24-hour with leading zero and minutes
+        'G:i', // 5:15 - 24-hour without leading zero and minutes
     ];
 
     /**

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -14,7 +14,7 @@ class Time
         'H',   // 05    - 24-hour with leading zero
         'G',   // 15    - 24-hour without leading zero
         'H:i', // 05:10 - 24-hour with leading zero and minutes
-        'G:i', // 5:15 - 24-hour without leading zero and minutes
+        'G:i', // 5:15  - 24-hour without leading zero and minutes
     ];
 
     /**

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -29,7 +29,7 @@ class Time
         $d = new DateTime();
         $time = $d->format('Y-m-d ') . strtolower($time);
 
-        foreach(self::$timeFormats as $format) {
+        foreach (self::$timeFormats as $format) {
             $date = DateTime::createFromFormat('Y-m-d ' . $format, $time);
 
             if ($date !== false) {

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -11,12 +11,12 @@ class Time
      * @var array<int, string>
      */
     private static array $timeFormats = [
-        'g a',   // 1 am  - 12-hour without leading zeros and lowercase am/pm
-        'G a',   // 01 am - 12-hour with leading zeros and lowercase am/pm
-        'ga',    // 1am   - 12-hour without leading zeros, lowercase am/pm and no space
-        'Ga',    // 01am  - 12-hour with leading zeros, lowercase am/pm and no space
-        'H',     // 05    - 24-hour with leading zeros
-        'H:i'    // 15:10 - 24-hour with leading zeros and minutes
+        'g a', // 1 am  - 12-hour without leading zeros and lowercase am/pm
+        'G a', // 01 am - 12-hour with leading zeros and lowercase am/pm
+        'ga',  // 1am   - 12-hour without leading zeros, lowercase am/pm and no space
+        'Ga',  // 01am  - 12-hour with leading zeros, lowercase am/pm and no space
+        'H',   // 05    - 24-hour with leading zeros
+        'H:i'  // 15:10 - 24-hour with leading zeros and minutes
     ];
 
     /**

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -11,28 +11,31 @@ class Time
      * @var array<int, string>
      */
     private static array $timeFormats = [
-        'H',   // 05    - 24-hour with leading zero
-        'G',   // 15    - 24-hour without leading zero
         'H:i', // 05:10 - 24-hour with leading zero and minutes
         'G:i', // 5:15  - 24-hour without leading zero and minutes
     ];
 
     /**
-     * Check if a time format is valid
+     * Check if a time is valid
      * @param string $time
      * @return bool
      */
     public static function isValid(string $time): bool
     {
-        $d = new DateTime();
-        $time = $d->format('Y-m-d ') . strtolower($time);
-
-        foreach (self::$timeFormats as $format) {
-            $date = DateTime::createFromFormat('Y-m-d ' . $format, $time);
-
-            if ($date !== false) {
-                return true;
+        try {
+            foreach (self::$timeFormats as $format) {
+                $date = DateTime::createFromFormat(
+                    'Y-m-d ' . $format,
+                    (new DateTime())->format('Y-m-d ') . strtolower($time)
+                );
+    
+                if ($date !== false) {
+                    new DateTime($time);
+                    return true;
+                }
             }
+        } catch (\Exception) {
+            return false;
         }
 
         return false;

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -28,7 +28,7 @@ class Time
                     'Y-m-d ' . $format,
                     (new DateTime())->format('Y-m-d ') . strtolower($time)
                 );
-    
+
                 if ($date !== false) {
                     new DateTime($time);
                     return true;

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -12,11 +12,11 @@ class Time
      */
     private static array $timeFormats = [
         'g a', // 1 am  - 12-hour without leading zeros and lowercase am/pm
-        'G a', // 01 am - 12-hour with leading zeros and lowercase am/pm
+        'h a', // 01 am - 12-hour with leading zeros and lowercase am/pm
         'ga',  // 1am   - 12-hour without leading zeros, lowercase am/pm and no space
-        'Ga',  // 01am  - 12-hour with leading zeros, lowercase am/pm and no space
+        'ha',  // 01am  - 12-hour with leading zeros, lowercase am/pm and no space
         'H',   // 05    - 24-hour with leading zeros
-        'H:i'  // 15:10 - 24-hour with leading zeros and minutes
+        'G',   // 15    - 24-hour without leading zeros
     ];
 
     /**

--- a/tests/ActiveHoursTest.php
+++ b/tests/ActiveHoursTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use Vigilant\ActiveHours;
+use Vigilant\Logger;
+
+#[CoversClass(ActiveHours::class)]
+#[UsesClass(Logger::class)]
+class ActiveHoursTest extends TestCase
+{
+    private static Logger $logger;
+    private static string $timezone = 'UTC';
+    private string $formatRegex = '/[0-9]{4}+\-[0-9]{2}+\-[0-9]{2}+ [0-9]{2}+\:[0-9]{2}+\:[0-9]{2}+ UTC/';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$logger = new Logger(self::$timezone);
+    }
+
+    /**
+     * Test class with time that is inside the active window
+     */
+    public function testActiveHoursInWindow(): void
+    {
+        $now = new DateTime('10:00', new DateTimeZone(self::$timezone));
+
+        $activeHours = new ActiveHours(
+            $now,
+            '06:00',
+            '20:00',
+            self::$timezone,
+            self::$logger
+        );
+
+        $this->assertTrue($activeHours->isEnabled());
+    }
+
+    /**
+     * Test class with time that is outside the active window
+     */
+    public function testActiveHoursOutsideWindow(): void
+    {
+        $now = new DateTime('05:00', new DateTimeZone(self::$timezone));
+
+        $activeHours = new ActiveHours(
+            $now,
+            '06:00',
+            '20:00',
+            self::$timezone,
+            self::$logger
+        );
+
+        $this->assertFalse($activeHours->isEnabled());
+    }
+
+    /**
+     * Test date and time formats returned by getStartTime() and getEndTime() with a regex
+     */
+    public function testGetMethodsDateAndTimeFormats()
+    {
+        $now = new DateTime('07:00', new DateTimeZone(self::$timezone));
+
+        $activeHours = new ActiveHours(
+            $now,
+            '06:00',
+            '20:00',
+            self::$timezone,
+            self::$logger
+        );
+
+        $this->assertMatchesRegularExpression(
+            $this->formatRegex,
+            $activeHours->getStartTime()
+        );
+
+        $this->assertMatchesRegularExpression(
+            $this->formatRegex,
+            $activeHours->getEndTime()
+        );
+    }
+}

--- a/tests/ActiveHoursTest.php
+++ b/tests/ActiveHoursTest.php
@@ -57,7 +57,7 @@ class ActiveHoursTest extends TestCase
     /**
      * Test date and time formats returned by getStartTime() and getEndTime() with a regex
      */
-    public function testGetMethodsDateAndTimeFormats()
+    public function testGetMethodsDateAndTimeFormats(): void
     {
         $now = new DateTime('07:00', new DateTimeZone(self::$timezone));
 

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -179,7 +179,7 @@ class DetailsTest extends TestCase
         );
     }
 
-    /** 
+    /**
      * Test getActiveHoursStartTime()
      */
     public function testGetActiveHoursStartTime(): void
@@ -194,7 +194,7 @@ class DetailsTest extends TestCase
         );
     }
 
-    /** 
+    /**
      * Test getActiveHoursEndTime()
      */
     public function testGetActiveHoursEndTime(): void

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -210,6 +210,15 @@ class DetailsTest extends TestCase
     }
 
     /**
+     * Test hasActiveHours()
+     */
+    public function testHasActiveHours(): void
+    {
+        $this->assertTrue(self::$details[1]->hasActiveHours());
+        $this->assertFalse(self::$details[0]->hasActiveHours());
+    }
+
+    /**
      * Test hasGotifyToken()
      */
     public function testHasGotifyToken(): void

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -12,10 +12,37 @@ class DetailsTest extends TestCase
      */
     private static array $feeds = [];
 
+    /**
+     * @var array<int, Details>
+     */
+    private static array $details = [];
+
     public static function setUpBeforeClass(): void
     {
         $feeds = Yaml::parse(self::loadSample('feeds.yaml'));
         self::$feeds = $feeds['feeds'];
+
+        self::$details = [
+            new Details(self::$feeds[0]),
+            new Details(self::$feeds[1])
+        ];
+    }
+
+    /**
+     * Test __construct
+     */
+    public function testConstruct(): void
+    {
+        $details = new Details(self::$feeds[0]);
+
+        $reflection = new ReflectionClass($details);
+        $property = $reflection->getProperty('details');
+        $property->setAccessible(true);
+
+        $this->assertEquals(
+            self::$feeds[0],
+            $property->getValue($details)
+        );
     }
 
     /**
@@ -23,12 +50,9 @@ class DetailsTest extends TestCase
      */
     public function testGetHash(): void
     {
-        $hashed = sha1(self::$feeds[0]['url']);
-        $details = new Details(self::$feeds[0]);
-
         $this->assertEquals(
-            $hashed,
-            $details->getHash()
+            sha1(self::$feeds[0]['url']),
+            self::$details[0]->getHash()
         );
     }
 
@@ -37,11 +61,9 @@ class DetailsTest extends TestCase
      */
     public function testGetName(): void
     {
-        $details = new Details(self::$feeds[0]);
-
         $this->assertEquals(
             self::$feeds[0]['name'],
-            $details->getName()
+            self::$details[0]->getName()
         );
     }
 
@@ -50,11 +72,9 @@ class DetailsTest extends TestCase
      */
     public function testGetUrl(): void
     {
-        $details = new Details(self::$feeds[0]);
-
         $this->assertEquals(
             self::$feeds[0]['url'],
-            $details->getUrl()
+            self::$details[0]->getUrl()
         );
     }
 
@@ -63,11 +83,9 @@ class DetailsTest extends TestCase
      */
     public function testGetInterval(): void
     {
-        $details = new Details(self::$feeds[0]);
-
         $this->assertEquals(
             self::$feeds[0]['interval'],
-            $details->getInterval()
+            self::$details[0]->getInterval()
         );
     }
 
@@ -76,11 +94,13 @@ class DetailsTest extends TestCase
      */
     public function testGetTitlePrefix(): void
     {
-        $details = new Details(self::$feeds[0]);
-
         $this->assertEquals(
             self::$feeds[0]['title_prefix'],
-            $details->getTitlePrefix()
+            self::$details[0]->getTitlePrefix()
+        );
+
+        $this->assertNull(
+            self::$details[1]->getTitlePrefix()
         );
     }
 
@@ -89,11 +109,13 @@ class DetailsTest extends TestCase
      */
     public function testGetGotifyToken(): void
     {
-        $details = new Details(self::$feeds[0]);
-
         $this->assertEquals(
             self::$feeds[0]['gotify_token'],
-            $details->getGotifyToken()
+            self::$details[0]->getGotifyToken()
+        );
+
+        $this->assertNull(
+            self::$details[1]->getGotifyToken()
         );
     }
 
@@ -102,11 +124,13 @@ class DetailsTest extends TestCase
      */
     public function testGetGotifyPriority(): void
     {
-        $details = new Details(self::$feeds[0]);
-
         $this->assertEquals(
             self::$feeds[0]['gotify_priority'],
-            $details->getGotifyPriority()
+            self::$details[0]->getGotifyPriority()
+        );
+
+        $this->assertNull(
+            self::$details[1]->getGotifyPriority()
         );
     }
 
@@ -115,11 +139,13 @@ class DetailsTest extends TestCase
      */
     public function testGetNtfyTopic(): void
     {
-        $details = new Details(self::$feeds[1]);
-
         $this->assertEquals(
             self::$feeds[1]['ntfy_topic'],
-            $details->getNtfyTopic()
+            self::$details[1]->getNtfyTopic()
+        );
+
+        $this->assertNull(
+            self::$details[0]->getNtfyTopic()
         );
     }
 
@@ -128,11 +154,13 @@ class DetailsTest extends TestCase
      */
     public function testGetNtfyToken(): void
     {
-        $details = new Details(self::$feeds[1]);
-
         $this->assertEquals(
             self::$feeds[1]['ntfy_token'],
-            $details->getNtfyToken()
+            self::$details[1]->getNtfyToken()
+        );
+
+        $this->assertNull(
+            self::$details[0]->getNtfyToken()
         );
     }
 
@@ -141,11 +169,43 @@ class DetailsTest extends TestCase
      */
     public function testGetNtfyPriority(): void
     {
-        $details = new Details(self::$feeds[1]);
-
         $this->assertEquals(
             self::$feeds[1]['ntfy_priority'],
-            $details->getNtfyPriority()
+            self::$details[1]->getNtfyPriority()
+        );
+
+        $this->assertNull(
+            self::$details[0]->getNtfyPriority()
+        );
+    }
+
+    /** 
+     * Test getActiveHoursStartTime()
+     */
+    public function testGetActiveHoursStartTime(): void
+    {
+        $this->assertEquals(
+            self::$feeds[1]['active_hours']['start_time'],
+            self::$details[1]->getActiveHoursStartTime()
+        );
+
+        $this->assertNull(
+            self::$details[0]->getActiveHoursStartTime()
+        );
+    }
+
+    /** 
+     * Test getActiveHoursEndTime()
+     */
+    public function testGetActiveHoursEndTime(): void
+    {
+        $this->assertEquals(
+            self::$feeds[1]['active_hours']['end_time'],
+            self::$details[1]->getActiveHoursEndTime()
+        );
+
+        $this->assertNull(
+            self::$details[0]->getActiveHoursEndTime()
         );
     }
 
@@ -154,8 +214,8 @@ class DetailsTest extends TestCase
      */
     public function testHasGotifyToken(): void
     {
-        $details = new Details(self::$feeds[0]);
-        $this->assertTrue($details->hasGotifyToken());
+        $this->assertTrue(self::$details[0]->hasGotifyToken());
+        $this->assertFalse(self::$details[1]->hasGotifyToken());
     }
 
     /**
@@ -163,8 +223,8 @@ class DetailsTest extends TestCase
      */
     public function testHasGotifyPriority(): void
     {
-        $details = new Details(self::$feeds[0]);
-        $this->assertTrue($details->hasGotifyPriority());
+        $this->assertTrue(self::$details[0]->hasGotifyPriority());
+        $this->assertFalse(self::$details[1]->hasGotifyPriority());
     }
 
     /**
@@ -172,17 +232,17 @@ class DetailsTest extends TestCase
      */
     public function testHasNtfyTopic(): void
     {
-        $details = new Details(self::$feeds[1]);
-        $this->assertTrue($details->hasNtfyTopic());
+        $this->assertTrue(self::$details[1]->hasNtfyTopic());
+        $this->assertFalse(self::$details[0]->hasNtfyTopic());
     }
 
     /**
-     * Test hasNtfyToken)
+     * Test hasNtfyToken()
      */
     public function testHasNtfyToken(): void
     {
-        $details = new Details(self::$feeds[1]);
-        $this->assertTrue($details->hasNtfyToken());
+        $this->assertTrue(self::$details[1]->hasNtfyToken());
+        $this->assertFalse(self::$details[0]->hasNtfyToken());
     }
 
     /**
@@ -190,16 +250,7 @@ class DetailsTest extends TestCase
      */
     public function testHasNtfyPriority(): void
     {
-        $details = new Details(self::$feeds[1]);
-        $this->assertTrue($details->hasNtfyPriority());
-    }
-
-    /**
-     * Test `hasNtfyPriority()` returning false
-     */
-    public function testHasNtfyPriorityNtfyPriorityFalse(): void
-    {
-        $details = new Details(self::$feeds[0]);
-        $this->assertFalse($details->hasNtfyPriority());
+        $this->assertTrue(self::$details[1]->hasNtfyPriority());
+        $this->assertFalse(self::$details[0]->hasNtfyPriority());
     }
 }

--- a/tests/Feed/FeedTest.php
+++ b/tests/Feed/FeedTest.php
@@ -3,11 +3,18 @@
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Vigilant\Config;
+use Vigilant\Logger;
 use Vigilant\Feed\Feed;
 use Symfony\Component\Yaml\Yaml;
 
 #[CoversClass(Feed::class)]
 #[UsesClass(Config::class)]
+#[UsesClass(Logger::class)]
+#[UsesClass(Vigilant\Cache::class)]
+#[UsesClass(Vigilant\Check::class)]
+#[UsesClass(Vigilant\Fetch::class)]
+#[UsesClass(Vigilant\ActiveHours::class)]
+#[UsesClass(Vigilant\Helper\File::class)]
 #[UsesClass(Vigilant\Feed\Details::class)]
 #[UsesClass(Vigilant\Feed\Validate::class)]
 #[UsesClass(Vigilant\Config\Validator::class)]
@@ -26,17 +33,18 @@ class FeedTest extends TestCase
     }
 
     /**
-     * Test get()
+     * Test class
      */
-    public function testGet(): void
+    public function testClass(): void
     {
-        $config = new Config();
+        $config = self::createStub(Config::class);
+        $config->method('getTimezone')->willReturn('UTC');
 
-        $feed = new Feed(self::$feeds[0], $config);
+        $feed = new Feed(self::$feeds[0], $config, new Logger('UTC'));
 
         $this->assertInstanceOf(
             'Vigilant\Feed\Details',
-            $feed->getDetails()
+            $feed->details
         );
     }
 }

--- a/tests/Feed/ValidateTest.php
+++ b/tests/Feed/ValidateTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Yaml\Yaml;
 
 #[CoversClass(Validate::class)]
 #[UsesClass(FeedsException::class)]
+#[UsesClass(Vigilant\Helper\Time::class)]
 class ValidateTest extends TestCase
 {
     /**
@@ -179,5 +180,82 @@ class ValidateTest extends TestCase
         $this->expectExceptionMessage('Empty Ntfy token given');
 
         new Validate(self::$feedsInvalid['emptyNtfyToken'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with no options for active hours
+     */
+    public function testNoActiveHoursOptions(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('Required active hours options not given');
+
+        new Validate(self::$feedsInvalid['noActiveHoursOptions'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with no start_time for active hours
+     */
+    public function testNoActiveHoursStartTime(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('No active hours start time given');
+
+        new Validate(self::$feedsInvalid['noActiveHoursStartTime'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with no end_time for active hours
+     */
+    public function testNoActiveHoursEndTime(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('No active hours end time given');
+
+        new Validate(self::$feedsInvalid['noActiveHoursEndTime'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with empty start_time for active hours
+     */
+    public function testEmptyActiveHoursStartTime(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('Empty active hours start time given');
+
+        new Validate(self::$feedsInvalid['emptyActiveHoursStartTime'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with empty end_time for active hours
+     */
+    public function testEmptyActiveHoursEndTime(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('Empty active hours end time given');
+
+        new Validate(self::$feedsInvalid['emptyActiveHoursEndTime'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with invalid start_time for active hours
+     */
+    public function testInvalidActiveHoursStartTime(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('Invalid active hours start time given');
+
+        new Validate(self::$feedsInvalid['invalidActiveHoursStartTime'], self::$minCheckInterval);
+    }
+
+    /**
+     * Test feed entry with invalid end_time for active hours
+     */
+    public function testInvalidActiveHoursEndTime(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('Invalid active hours end time given');
+
+        new Validate(self::$feedsInvalid['invalidActiveHoursEndTime'], self::$minCheckInterval);
     }
 }

--- a/tests/Feed/ValidateTest.php
+++ b/tests/Feed/ValidateTest.php
@@ -258,4 +258,15 @@ class ValidateTest extends TestCase
 
         new Validate(self::$feedsInvalid['invalidActiveHoursEndTime'], self::$minCheckInterval);
     }
+
+    /**
+     * Test feed entry with active hours end time that is before start time
+     */
+    public function testActiveHoursEndTimeBeforeStartTime(): void
+    {
+        $this->expectException(FeedsException::class);
+        $this->expectExceptionMessage('Active hours end time is before the start time');
+
+        new Validate(self::$feedsInvalid['activeHoursEndTimeBeforeStartTime'], self::$minCheckInterval);
+    }
 }

--- a/tests/FeedsTest.php
+++ b/tests/FeedsTest.php
@@ -15,6 +15,7 @@ use Vigilant\Exception\AppException;
 #[UsesClass(Vigilant\Feed\Feed::class)]
 #[UsesClass(Vigilant\Feed\Details::class)]
 #[UsesClass(Vigilant\Feed\Validate::class)]
+#[UsesClass(Vigilant\Helper\Time::class)]
 #[UsesClass(Vigilant\Exception\FeedsException::class)]
 class FeedsTest extends TestCase
 {

--- a/tests/FeedsTest.php
+++ b/tests/FeedsTest.php
@@ -11,11 +11,16 @@ use Vigilant\Exception\AppException;
 #[UsesClass(Config::class)]
 #[UsesClass(Logger::class)]
 #[UsesClass(AppException::class)]
+#[UsesClass(Vigilant\Cache::class)]
+#[UsesClass(Vigilant\Check::class)]
+#[UsesClass(Vigilant\Fetch::class)]
 #[UsesClass(Vigilant\Output::class)]
 #[UsesClass(Vigilant\Feed\Feed::class)]
 #[UsesClass(Vigilant\Feed\Details::class)]
 #[UsesClass(Vigilant\Feed\Validate::class)]
+#[UsesClass(Vigilant\ActiveHours::class)]
 #[UsesClass(Vigilant\Helper\Time::class)]
+#[UsesClass(Vigilant\Helper\File::class)]
 #[UsesClass(Vigilant\Exception\FeedsException::class)]
 class FeedsTest extends TestCase
 {
@@ -34,11 +39,12 @@ class FeedsTest extends TestCase
         /** @var PHPUnit\Framework\MockObject\Stub&Config */
         $config = $this->createStub(Config::class);
         $config->method('getFeedsPath')->willReturn(self::getSamplePath('feeds.yaml'));
+        $config->method('getTimezone')->willReturn('UTC');
 
         $feeds = new Feeds($config, self::$logger);
 
         $this->assertIsArray($feeds->get());
-        $this->assertContainsOnlyInstancesOf('Vigilant\Feed\Details', $feeds->get());
+        $this->assertContainsOnlyInstancesOf('Vigilant\Feed\Feed', $feeds->get());
     }
 
     /**

--- a/tests/Helper/Time.php
+++ b/tests/Helper/Time.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use Vigilant\Helper\Time;
+use Vigilant\Exception\AppException;
+
+#[CoversClass(Time::class)]
+#[UsesClass(AppException::class)]
+class TimeTest extends TestCase
+{
+    // 'g a', 1 am  - 12-hour without leading zeros and lowercase am/pm
+    // 'G a', 01 am - 12-hour with leading zeros and lowercase am/pm
+    // 'ga',  1am   - 12-hour without leading zeros, lowercase am/pm and no space
+    // 'ha',  01am  - 12-hour with leading zeros, lowercase am/pm and no space
+    // 'H',   05    - 24-hour with leading zeros
+    // 'G',   15    - 24-hour without leading zeros
+    #[TestWith(['1 am', true])]
+    #[TestWith(['01 am', true])]
+    #[TestWith(['1am', true])]
+    #[TestWith(['01am', true])]
+    #[TestWith(['05', true])]
+	#[TestWith(['15', true])]
+    public function testIsValid(string $time, bool $expected): void
+    {
+        $this->assertEquals($expected, Time::isValid($time));
+    }
+}

--- a/tests/Helper/TimeTest.php
+++ b/tests/Helper/TimeTest.php
@@ -10,15 +10,12 @@ use Vigilant\Exception\AppException;
 #[UsesClass(AppException::class)]
 class TimeTest extends TestCase
 {
-    // 'H'   05    - 24-hour with leading zero
-    // 'G'   15    - 24-hour without leading zero
     // 'H:i' 05:10 - 24-hour with leading zero and minutes
     // 'G:i' 5:10  - 24-hour without leading zero and minutes
-    #[TestWith(['05', true])]
-    #[TestWith(['15', true])]
     #[TestWith(['05:10', true])]
     #[TestWith(['5:10', true])]
     #[TestWith(['1am', false])]
+    #[TestWith(['25:00', false])]
     public function testIsValid(string $time, bool $expected): void
     {
         $this->assertEquals($expected, Time::isValid($time));

--- a/tests/Helper/TimeTest.php
+++ b/tests/Helper/TimeTest.php
@@ -21,7 +21,7 @@ class TimeTest extends TestCase
     #[TestWith(['1am', true])]
     #[TestWith(['01am', true])]
     #[TestWith(['05', true])]
-	#[TestWith(['15', true])]
+    #[TestWith(['15', true])]
     #[TestWith(['15:00', false])]
     public function testIsValid(string $time, bool $expected): void
     {

--- a/tests/Helper/TimeTest.php
+++ b/tests/Helper/TimeTest.php
@@ -10,19 +10,15 @@ use Vigilant\Exception\AppException;
 #[UsesClass(AppException::class)]
 class TimeTest extends TestCase
 {
-    // 'g a', 1 am  - 12-hour without leading zeros and lowercase am/pm
-    // 'G a', 01 am - 12-hour with leading zeros and lowercase am/pm
-    // 'ga',  1am   - 12-hour without leading zeros, lowercase am/pm and no space
-    // 'ha',  01am  - 12-hour with leading zeros, lowercase am/pm and no space
-    // 'H',   05    - 24-hour with leading zeros
-    // 'G',   15    - 24-hour without leading zeros
-    #[TestWith(['1 am', true])]
-    #[TestWith(['01 am', true])]
-    #[TestWith(['1am', true])]
-    #[TestWith(['01am', true])]
+    // 'H'   05    - 24-hour with leading zero
+    // 'G'   15    - 24-hour without leading zero
+    // 'H:i' 05:10 - 24-hour with leading zero and minutes
+    // 'G:i' 5:10  - 24-hour without leading zero and minutes
     #[TestWith(['05', true])]
     #[TestWith(['15', true])]
-    #[TestWith(['15:00', false])]
+    #[TestWith(['05:10', true])]
+    #[TestWith(['5:10', true])]
+    #[TestWith(['1am', false])]
     public function testIsValid(string $time, bool $expected): void
     {
         $this->assertEquals($expected, Time::isValid($time));

--- a/tests/Helper/TimeTest.php
+++ b/tests/Helper/TimeTest.php
@@ -22,6 +22,7 @@ class TimeTest extends TestCase
     #[TestWith(['01am', true])]
     #[TestWith(['05', true])]
 	#[TestWith(['15', true])]
+    #[TestWith(['15:00', false])]
     public function testIsValid(string $time, bool $expected): void
     {
         $this->assertEquals($expected, Time::isValid($time));

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -106,7 +106,7 @@ feeds:
     interval: 300
     ntfy_token: token
     active_hours:
-      start_time: 6am
+      start_time: 06:00
       end_time:
 
   invalidActiveHoursStartTime:
@@ -115,8 +115,8 @@ feeds:
     interval: 300
     ntfy_token: token
     active_hours:
-      start_time: 06:00:12
-      end_time: 10pm
+      start_time: 06am
+      end_time: 21:00
 
   invalidActiveHoursEndTime:
     name: Example.com Feed
@@ -124,5 +124,5 @@ feeds:
     interval: 300
     ntfy_token: token
     active_hours:
-      start_time: 6am
-      end_time: 10:01:12
+      start_time: 06:00
+      end_time: 10pm

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -67,3 +67,62 @@ feeds:
     interval: 300
     ntfy_priority: 1
     ntfy_token:
+
+  noActiveHoursOptions:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    ntfy_token: token
+    active_hours:
+
+  noActiveHoursStartTime:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    ntfy_token: token
+    active_hours:
+      test: Hello World
+
+  noActiveHoursEndTime:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    ntfy_token: token
+    active_hours:
+      start_time: 22:00
+
+  emptyActiveHoursStartTime:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    ntfy_token: token
+    active_hours:
+      start_time:
+      end_time: 22:00
+
+  emptyActiveHoursEndTime:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    ntfy_token: token
+    active_hours:
+      start_time: 6am
+      end_time:
+
+  invalidActiveHoursStartTime:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    ntfy_token: token
+    active_hours:
+      start_time: 06:00:12
+      end_time: 10pm
+
+  invalidActiveHoursEndTime:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    ntfy_token: token
+    active_hours:
+      start_time: 6am
+      end_time: 10:01:12

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -126,3 +126,11 @@ feeds:
     active_hours:
       start_time: 06:00
       end_time: 10pm
+
+  activeHoursEndTimeBeforeStartTime:
+    name: Example.com Feed
+    url: https://www.example.com/feed.rss
+    interval: 300
+    active_hours:
+      start_time: 06:00
+      end_time: 05:00

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -14,5 +14,5 @@ feeds:
      ntfy_priority: 1
      ntfy_token: HQKPyHCODeoMFuN
      active_hours:
-       start_time: 6am
-       end_time: 9pm
+       start_time: 06:00
+       end_time: 21:00

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -13,4 +13,6 @@ feeds:
      ntfy_topic: GitHub_status
      ntfy_priority: 1
      ntfy_token: HQKPyHCODeoMFuN
-
+     active_hours:
+       start_time: 6am
+       end_time: 9pm


### PR DESCRIPTION
Adds active hours parameters to restrict monitoring of a feed to a specific time window during the day. Addresses #189

```YAML
feeds:
    - name: GitHub Status
      url: https://www.githubstatus.com/history.rss
      interval: 600
      active_hours:
        start_time: '09:30'
        end_time: '17:00'
```