### PR TITLE
Enforce strict typing

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,8 @@
 <ruleset name="vigilant">
   <exclude-pattern>./cache</exclude-pattern>
   <exclude-pattern>./vendor</exclude-pattern>
+  <exclude-pattern>./site</exclude-pattern>
+  <exclude-pattern>./.cache</exclude-pattern>
   <exclude-pattern>./coverage-reports</exclude-pattern>
 
   <rule ref="PSR12"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,6 +5,10 @@
   <exclude-pattern>./coverage-reports</exclude-pattern>
 
   <rule ref="PSR12"/>
+  <rule ref="Generic.PHP.RequireStrictTypes">
+    <exclude-pattern>./config.php</exclude-pattern>
+    <exclude-pattern>./config.example.php</exclude-pattern>
+  </rule>
   <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
     <exclude-pattern>./tests/*</exclude-pattern>
   </rule>

--- a/src/ActiveHours.php
+++ b/src/ActiveHours.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use DateTime;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use Vigilant\Helper\File;

--- a/src/Check.php
+++ b/src/Check.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use DateTime;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use Vigilant\Config\Validator;

--- a/src/Config/AbstractValidator.php
+++ b/src/Config/AbstractValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Config;
 
 abstract class AbstractValidator

--- a/src/Config/Validate/Gotify.php
+++ b/src/Config/Validate/Gotify.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Config\Validate;
 
 use Vigilant\Config\AbstractValidator;

--- a/src/Config/Validate/Ntfy.php
+++ b/src/Config/Validate/Ntfy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Config\Validate;
 
 use Vigilant\Config\AbstractValidator;

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Config;
 
 use DateTimeZone;

--- a/src/Exception/AppException.php
+++ b/src/Exception/AppException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Exception;
 
 class AppException extends \Exception

--- a/src/Exception/CheckException.php
+++ b/src/Exception/CheckException.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Vigilant\Exception;
+declare(strict_types=1);
 
-use Throwable;
+namespace Vigilant\Exception;
 
 class CheckException extends \Exception
 {

--- a/src/Exception/ConfigException.php
+++ b/src/Exception/ConfigException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Exception;
 
 use Throwable;

--- a/src/Exception/FeedsException.php
+++ b/src/Exception/FeedsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Exception;
 
 use Throwable;

--- a/src/Exception/FetchException.php
+++ b/src/Exception/FetchException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Exception;
 
 class FetchException extends \Exception

--- a/src/Exception/NotificationException.php
+++ b/src/Exception/NotificationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Exception;
 
 use Throwable;

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Feed;
 
 final class Details

--- a/src/Feed/Feed.php
+++ b/src/Feed/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Feed;
 
 use DateTime;

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Feed;
 
 use DateTime;

--- a/src/Feeds.php
+++ b/src/Feeds.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use Vigilant\Feed\Feed;
-use Vigilant\Feed\Details;
 use Vigilant\Exception\AppException;
 use Vigilant\Exception\FeedsException;
 use Symfony\Component\Yaml\Yaml;

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use FeedIo\FeedIo;

--- a/src/Helper/File.php
+++ b/src/Helper/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Helper;
 
 use Vigilant\Exception\AppException;

--- a/src/Helper/Json.php
+++ b/src/Helper/Json.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Helper;
 
 use JsonException;

--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Helper;
 
 use DateTime;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use DateTime;

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 class Message

--- a/src/Notification/AbstractNotification.php
+++ b/src/Notification/AbstractNotification.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Notification;
 
 use Vigilant\Logger;

--- a/src/Notification/Gotify.php
+++ b/src/Notification/Gotify.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Notification;
 
 use Vigilant\Notification\AbstractNotification;

--- a/src/Notification/Ntfy.php
+++ b/src/Notification/Ntfy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant\Notification;
 
 use Vigilant\Notification\AbstractNotification;

--- a/src/Notify.php
+++ b/src/Notify.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 use Vigilant\Notification\Gotify;

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 class Version

--- a/tests/ActiveHoursTest.php
+++ b/tests/ActiveHoursTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Vigilant\ActiveHours;

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/tests/Config/AbstractValidatorTest.php
+++ b/tests/Config/AbstractValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Config\AbstractValidator;
 

--- a/tests/Config/Validate/GotifyTest.php
+++ b/tests/Config/Validate/GotifyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\Config\Validate;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Config/Validate/NtfyTest.php
+++ b/tests/Config/Validate/NtfyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\Config\Validate;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Config/ValidatorTest.php
+++ b/tests/Config/ValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\Config\Validate;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Vigilant\Config;

--- a/tests/Exception/ConfigExceptionTest.php
+++ b/tests/Exception/ConfigExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Exception\ConfigException;
 

--- a/tests/Exception/FeedsExceptionTest.php
+++ b/tests/Exception/FeedsExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Exception\FeedsException;
 

--- a/tests/Exception/NotificationExceptionTest.php
+++ b/tests/Exception/NotificationExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Exception\NotificationException;
 

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Feed\Details;
 use Symfony\Component\Yaml\Yaml;

--- a/tests/Feed/FeedTest.php
+++ b/tests/Feed/FeedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Vigilant\Config;

--- a/tests/Feed/ValidateTest.php
+++ b/tests/Feed/ValidateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/FeedsTest.php
+++ b/tests/FeedsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Vigilant\Feeds;

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Vigilant\Fetch;

--- a/tests/Helper/FileTest.php
+++ b/tests/Helper/FileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/tests/Helper/JsonTest.php
+++ b/tests/Helper/JsonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Vigilant\Helper\Json;

--- a/tests/Helper/TimeTest.php
+++ b/tests/Helper/TimeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Logger;
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Message;
 use Vigilant\Helper\Json;

--- a/tests/Notification/GotifyTest.php
+++ b/tests/Notification/GotifyTest.php
@@ -1,5 +1,7 @@
 <?Php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;

--- a/tests/Notification/NtfyTest.php
+++ b/tests/Notification/NtfyTest.php
@@ -1,5 +1,7 @@
 <?Php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;

--- a/tests/NotifyTest.php
+++ b/tests/NotifyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use Vigilant\Version;
 

--- a/vigilant.php
+++ b/vigilant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Vigilant\Config;
 use Vigilant\Feeds;
 use Vigilant\Notify;


### PR DESCRIPTION
Enforces strict typing by adding `declare(strict_types=1);` to all php files excluding `config.php` and `config.example.php`.