### PR TITLE
Check: Fallback to getSummary()

### DIFF
--- a/src/Check.php
+++ b/src/Check.php
@@ -142,7 +142,7 @@ final class Check
                 $newItems += 1;
 
                 $title = html_entity_decode($item->getTitle());
-                $body = strip_tags(html_entity_decode($item->getContent() ?? $item->getDescription() ?? ''));
+                $body = strip_tags(html_entity_decode($item->getContent() ?? $item->getSummary() ?? ''));
 
                 $this->logger->info(sprintf('Found...%s (%s)', $title, $hash));
 

--- a/src/Check.php
+++ b/src/Check.php
@@ -142,7 +142,7 @@ final class Check
                 $newItems += 1;
 
                 $title = html_entity_decode($item->getTitle());
-                $body = strip_tags(html_entity_decode($item->getContent()));
+                $body = strip_tags(html_entity_decode($item->getContent() ?? $item->getDescription() ?? ''));
 
                 $this->logger->info(sprintf('Found...%s (%s)', $title, $hash));
 


### PR DESCRIPTION
This will fix ATOM feeds that don't have `<content>` but rather a `<summary>` instead.

Also closes #403 