### PR TITLE
Add support for per feed gotify server URLs

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -39,6 +39,7 @@ feeds:
 
 | Name              | Required | Type    | Description                                                |
 | ----------------- | -------- | ------- | ----------------------------------------------------------------------------- |
+| `gotify_url`      | No       | string  | Gotify server URL. Overrides URL set with an environment variable.            |
 | `gotify_token`    | No       | string  | Gotify application token. Overrides token set with an environment variable.   |
 | `gotify_priority` | No       | integer | Gotify message priority. Overrides default value and/or environment variable. |
 | `ntfy_topic`      | No       | string  | Ntfy topic. Overrides topic set with an environment variable.                 |

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -68,6 +68,16 @@ final class Details
     }
 
     /**
+     * Returns gotify server url
+     *
+     * @return ?string
+     */
+    public function getGotifyUrl(): ?string
+    {
+        return $this->details['gotify_url'] ?? null;
+    }
+
+    /**
      * Get gotify applications token
      *
      * @return ?string

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -31,6 +31,7 @@ final class Validate
         $this->titlePrefix();
         $this->messageTruncation();
 
+        $this->gotifyUrl();
         $this->gotifyToken();
         $this->gotifyPriority();
 
@@ -129,6 +130,18 @@ final class Validate
                     $this->details['name']
                 ));
             }
+        }
+    }
+
+    /**
+     * Validate entry gotify URL
+     *
+     * @throws FeedsException if gotify url is empty
+     */
+    private function gotifyUrl(): void
+    {
+        if (array_key_exists('gotify_url', $this->details) === true && $this->details['gotify_url'] === null) {
+            throw new FeedsException(sprintf('Empty Gotify url given for feed: %s', $this->details['name']));
         }
     }
 

--- a/src/Notify.php
+++ b/src/Notify.php
@@ -70,6 +70,10 @@ class Notify
             'token' => $this->config->getGotifyToken()
         ];
 
+        if ($details->getGotifyUrl() !== null) {
+            $gotifyConfig['server'] = $details->getGotifyUrl();
+        }
+
         if ($details->hasGotifyPriority() === true) {
             $gotifyConfig['priority'] = $details->getGotifyPriority();
         }

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -110,6 +110,21 @@ class DetailsTest extends TestCase
     }
 
     /**
+     * Test getGotifyUrl()
+     */
+    public function testGetGotifyUrl(): void
+    {
+        $this->assertEquals(
+            self::$feeds[0]['gotify_url'],
+            self::$details[0]->getGotifyUrl()
+        );
+
+        $this->assertNull(
+            self::$details[1]->getGotifyUrl()
+        );
+    }
+
+    /**
      * Test getGotifyToken()
      */
     public function testGetGotifyToken(): void

--- a/tests/NotifyTest.php
+++ b/tests/NotifyTest.php
@@ -106,6 +106,27 @@ class NotifyTest extends TestCase
     }
 
    /**
+    * Test creating Gotify instance with server url from feed details
+    */
+    public function testCreatingGotifyWithServerFromFeedDetails(): void
+    {
+        $config = $this->createConfigStubForGotify();
+
+        $feed = $this->feed;
+        $feed['gotify_url'] = 'https://gotify.example.com';
+
+        $notify = new notify(new Details($feed), $config, self::$logger);
+
+        $notifyReflection = new \ReflectionClass('Vigilant\Notify');
+        $service = $notifyReflection->getProperty('service')->getValue($notify);
+
+        $gotifyReflection = new \ReflectionClass('Vigilant\Notification\Gotify');
+        $gotifyConfig = $gotifyReflection->getProperty('config')->getValue($service);
+
+        $this->assertEquals($feed['gotify_url'], $gotifyConfig['server']);
+    }
+
+   /**
     * Test creating Gotify instance with priority from feed details
     */
     public function testCreatingGotifyWithPriorityFromFeedDetails(): void

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -53,6 +53,14 @@ feeds:
       interval: 300
       title_prefix:
 
+  emptyGotifyUrl:
+    exception: Empty Gotify url given
+    data:
+      name: Example.com Feed
+      url: https://www.example.com/feed.rss
+      interval: 300
+      gotify_url:
+
   emptyGotifyToken:
     exception: Empty Gotify token given
     data:

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -4,6 +4,7 @@ feeds:
      url: http://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/UK
      interval: 900
      title_prefix: Weather Alert!
+     gotify_url: https://gotify.example.com
      gotify_token: 7ZHeHM3awd45rn9W
      gotify_priority: 1
     -


### PR DESCRIPTION
Adds support for setting per feed gotify server URLs in feeds.yaml.

Example: 
```YAML
feeds:
    -
     name: Met Office weather warnings
     url: http://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/UK
     interval: 900
     title_prefix: Weather Alert!
     gotify_url: https://gotify.example.com
     gotify_token: 7ZHeHM3awd45rn9W
     gotify_priority: 1
```