### PR TITLE
Add support for per feed Ntfy server URLs

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -42,6 +42,7 @@ feeds:
 | `gotify_url`      | No       | string  | Gotify server URL. Overrides URL set with an environment variable.            |
 | `gotify_token`    | No       | string  | Gotify application token. Overrides token set with an environment variable.   |
 | `gotify_priority` | No       | integer | Gotify message priority. Overrides default value and/or environment variable. |
+| `ntfy_url`        | No       | string  | Ntfy server URL. Overrides URL set with an environment variable.              |
 | `ntfy_topic`      | No       | string  | Ntfy topic. Overrides topic set with an environment variable.                 |
 | `ntfy_token`      | No       | string  | Ntfy access token. Overrides token set with an environment variable.          |
 | `ntfy_priority`   | No       | integer | Ntfy message priority. Overrides default value and/or environment variable.   |

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -98,6 +98,16 @@ final class Details
     }
 
     /**
+     * Returns ntfy server url
+     *
+     * @return ?string
+     */
+    public function getNtfyUrl(): ?string
+    {
+        return $this->details['ntfy_url'] ?? null;
+    }
+
+    /**
      * Get Ntfy auth token
      *
      * @return ?string

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -35,6 +35,7 @@ final class Validate
         $this->gotifyToken();
         $this->gotifyPriority();
 
+        $this->ntfyUrl();
         $this->ntfyTopic();
         $this->ntfyToken();
         $this->ntfyPriority();
@@ -169,6 +170,18 @@ final class Validate
              $this->details['gotify_priority'] === null
         ) {
             throw new FeedsException(sprintf('Empty Gotify priority given for feed: %s', $this->details['name']));
+        }
+    }
+
+    /**
+     * Validate entry ntfy URL
+     *
+     * @throws FeedsException if ntfy url is empty
+     */
+    private function ntfyUrl(): void
+    {
+        if (array_key_exists('ntfy_url', $this->details) === true && $this->details['ntfy_url'] === null) {
+            throw new FeedsException(sprintf('Empty Ntfy url given for feed: %s', $this->details['name']));
         }
     }
 

--- a/src/Notify.php
+++ b/src/Notify.php
@@ -101,6 +101,10 @@ class Notify
             ]
         ];
 
+        if ($details->getNtfyUrl() !== null) {
+            $ntfyConfig['server'] = $details->getNtfyUrl();
+        }
+
         if ($this->config->getNtfyAuthMethod() === 'password') {
             $ntfyConfig['auth']['username'] = $this->config->getNtfyUsername();
             $ntfyConfig['auth']['password'] = $this->config->getNtfyPassword();

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -160,12 +160,12 @@ class DetailsTest extends TestCase
     public function testGetNtfyUrl(): void
     {
         $this->assertEquals(
-            self::$feeds[0]['ntfy_url'],
-            self::$details[0]->getNtfyUrl()
+            self::$feeds[1]['ntfy_url'],
+            self::$details[1]->getNtfyUrl()
         );
 
         $this->assertNull(
-            self::$details[1]->getNtfyUrl()
+            self::$details[0]->getNtfyUrl()
         );
     }
 

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -155,6 +155,21 @@ class DetailsTest extends TestCase
     }
 
     /**
+     * Test getNtfyUrl()
+     */
+    public function testGetNtfyUrl(): void
+    {
+        $this->assertEquals(
+            self::$feeds[0]['ntfy_url'],
+            self::$details[0]->getNtfyUrl()
+        );
+
+        $this->assertNull(
+            self::$details[1]->getNtfyUrl()
+        );
+    }
+
+    /**
      * Test getNtfyTopic()
      */
     public function testGetNtfyTopic(): void

--- a/tests/NotifyTest.php
+++ b/tests/NotifyTest.php
@@ -236,6 +236,27 @@ class NotifyTest extends TestCase
     }
 
    /**
+    * Test creating Ntfy instance with server URL from feed details
+    */
+    public function testCreatingNtfyWithUrlFromFeedDetails(): void
+    {
+        $config = $this->createConfigStubForNtfy();
+
+        $feed = $this->feed;
+        $feed['ntfy_url'] = 'https://ntfy.example.com';
+
+        $notify = new notify(new Details($feed), $config, self::$logger);
+
+        $notifyReflection = new \ReflectionClass('Vigilant\Notify');
+        $service = $notifyReflection->getProperty('service')->getValue($notify);
+
+        $ntfyReflection = new \ReflectionClass('Vigilant\Notification\Ntfy');
+        $ntfyConfig = $ntfyReflection->getProperty('config')->getValue($service);
+
+        $this->assertEquals($feed['ntfy_url'], $ntfyConfig['server']);
+    }
+
+   /**
     * Test creating Ntfy instance with token from feed details
     */
     public function testCreatingNtfyWithTokenFromFeedDetails(): void

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -77,6 +77,14 @@ feeds:
       interval: 300
       gotify_priority:
 
+  emptyNtfyUrl:
+    exception: Empty Ntfy url given
+    data:
+      name: Example.com Feed
+      url: https://www.example.com/feed.rss
+      interval: 300
+      ntfy_url:
+
   emptyNtfyTopic:
     exception: Empty Ntfy topic given
     data:

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -11,6 +11,7 @@ feeds:
      name: GitHub status
      url: https://www.githubstatus.com/history.rss
      interval: 300
+     ntfy_url: https://ntfy.example.com
      ntfy_topic: GitHub_status
      ntfy_priority: 1
      ntfy_token: HQKPyHCODeoMFuN

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -13,8 +13,8 @@ feeds:
      interval: 300
      ntfy_url: https://ntfy.example.com
      ntfy_topic: GitHub_status
-     ntfy_priority: 1
      ntfy_token: HQKPyHCODeoMFuN
+     ntfy_priority: 1
      truncate: true
      truncate_length: 150
      active_hours:


### PR DESCRIPTION
Adds support for setting per feed Ntfy server URLs in feeds.yaml.

Example: 
```YAML
feeds:
    -
     name: Met Office weather warnings
     url: http://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/UK
     interval: 900
     title_prefix: Weather Alert!
     ntfy _url: https://ntfy.example.com
     ntfy_topic: weather-alerts
```