### PR TITLE
Add support for overriding notification titles

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -32,6 +32,7 @@ feeds:
 | `url`             | **Yes**  | string  | Feed URL                                                                                        |
 | `interval`        | **Yes**  | integer | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).                    |
 | `title_prefix`    | No       | string  | Text to prepend to notification titles.                                                         |
+| `title_override`  | No       | string  | Text to use as notification title, overrides value from RSS/ATOM/JSON feed.                     |
 | `truncate`        | No       | boolean | Truncate notification text. Disabled by default. Use `truncate_length` to set custom length.    |
 | `truncate_length` | No       | integer | Number of characters to truncate notification text to. Minimum is `0` and the default is `200`. |
 

--- a/src/Check.php
+++ b/src/Check.php
@@ -141,7 +141,7 @@ final class Check
             if (in_array($hash, $this->cache->getItems()) === false) {
                 $newItems += 1;
 
-                $title = html_entity_decode($item->getTitle());
+                $title = html_entity_decode($this->details->getTitleOverride() ?? $item->getTitle());
                 $body = strip_tags(html_entity_decode($item->getContent() ?? $item->getSummary() ?? ''));
 
                 $this->logger->info(sprintf('Found...%s (%s)', $title, $hash));

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -68,6 +68,16 @@ final class Details
     }
 
     /**
+     * Returns title override
+     *
+     * @return ?string
+     */
+    public function getTitleOverride(): ?string
+    {
+        return $this->details['title_override'] ?? null;
+    }
+
+    /**
      * Returns gotify server url
      *
      * @return ?string

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -38,6 +38,7 @@ final class Validate
         $this->name();
         $this->url();
         $this->interval($minCheckInterval);
+        $this->titleOverride();
         $this->titlePrefix();
         $this->messageTruncation();
 
@@ -114,6 +115,22 @@ final class Validate
                 $minCheckInterval,
                 $this->details['name']
             ));
+        }
+    }
+
+    /**
+     * Validate entry title override
+     *
+     * @throws FeedsException if title override is empty
+     */
+    private function titleOverride(): void
+    {
+        if (array_key_exists('title_override', $this->details) === true) {
+            if ($this->details['title_override'] === null || $this->details['title_override'] === '') {
+                throw new FeedsException(sprintf('Empty title override given for feed: %s', $this->details['name']));
+            }
+
+            $this->details['title_override'] = $this->details['title_override'];
         }
     }
 

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -136,6 +136,34 @@ class CheckTest extends TestCase
     }
 
     /**
+     * Test `check()` with a feed that has `title_override` configured in its feed.yaml entry
+     */
+    public function testCheckWithTitleOverrideConfigured(): void
+    {
+        $feed = $this->feed;
+        $feed['title_override'] = 'An overridden item title';
+
+        $this->createCacheFIle(sha1( $feed['url']), $this->cache);
+
+        $mock = new GuzzleHttp\Handler\MockHandler([
+            new GuzzleHttp\Psr7\Response(200, body: (string) file_get_contents('tests/files/rss-feed.xml'))
+        ]);
+        $fetch = new Fetch(new \GuzzleHttp\Client([
+            'handler' => GuzzleHttp\HandlerStack::create($mock)
+        ]));
+
+        $details = new Details( $feed);
+        $check = new check($details, $fetch, self::$config, self::$logger);
+
+        $this->expectOutputRegex('/Found 1 new item\(s\)/');
+
+        $check->check();
+        $messages = $check->getMessages();
+
+        $this->assertEquals($feed['title_override'], $messages[0]->getTitle());
+    }
+
+    /**
      * Test `check()` when `Fetch` class returns an error and
      * cache `error_count` value is one below the max to trigger a message
      * telling the user that fetching the feed has repeatedly failed.

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -143,7 +143,7 @@ class CheckTest extends TestCase
         $feed = $this->feed;
         $feed['title_override'] = 'An overridden item title';
 
-        $this->createCacheFIle(sha1( $feed['url']), $this->cache);
+        $this->createCacheFIle(sha1($feed['url']), $this->cache);
 
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, body: (string) file_get_contents('tests/files/rss-feed.xml'))
@@ -152,7 +152,7 @@ class CheckTest extends TestCase
             'handler' => GuzzleHttp\HandlerStack::create($mock)
         ]));
 
-        $details = new Details( $feed);
+        $details = new Details($feed);
         $check = new check($details, $fetch, self::$config, self::$logger);
 
         $this->expectOutputRegex('/Found 1 new item\(s\)/');

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -95,6 +95,21 @@ class DetailsTest extends TestCase
     }
 
     /**
+     * Test getTitleOverride()
+     */
+    public function testGetTitleOverride(): void
+    {
+        $this->assertEquals(
+            self::$feeds[1]['title_override'],
+            self::$details[1]->getTitleOverride()
+        );
+
+        $this->assertNull(
+            self::$details[0]->getTitleOverride()
+        );
+    }
+
+    /**
      * Test getTitlePrefix()
      */
     public function testGetTitlePrefix(): void

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -52,6 +52,14 @@ feeds:
       url: https://www.example.com/feed.rss
       interval: 100
 
+  emptyTitleOverride:
+    exception: Empty title override given
+    data:
+      name: Example.com Feed
+      url: https://www.example.com/feed.rss
+      interval: 300
+      title_override:
+
   emptyTitlePrefix:
     exception: Empty title prefix given
     data:

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -12,6 +12,7 @@ feeds:
      name: GitHub status
      url: https://www.githubstatus.com/history.rss
      interval: 300
+     title_override: New Github service status
      ntfy_url: https://ntfy.example.com
      ntfy_topic: GitHub_status
      ntfy_token: HQKPyHCODeoMFuN


### PR DESCRIPTION
Adds support for overriding notification titles for a feed with a custom value via feeds.yaml

Example: 
```YAML
feeds:
    -
     name: GitHub status
     url: https://www.githubstatus.com/history.rss
     interval: 300
     title_override: New Github service status
```