### PR TITLE
Add support for custom user agents

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -6,15 +6,23 @@ Alternatively, you can use `config.php` (copied from [`config.example.php`](http
 
 ## Timezone
 
-By default Vigilant uses the timezone of the host system or UTC when running in docker, this behavior can be overridden by setting the environment variable `VIGILANT_TIMEZONE`.
+By default, Vigilant uses the timezone of the host system or UTC when running in docker, this behaviour can be overridden by setting the environment variable `VIGILANT_TIMEZONE`.
 
 | Name                | Description                                                         |
 | ------------------- | ------------------------------------------------------------------- |
 | `VIGILANT_TIMEZONE` | Timezone ([php docs](https://www.php.net/manual/en/timezones.php)). |
 
+## User agent
+
+By default, Vigilant uses the user agent `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)` when fetching feeds, this behaviour can be overridden by setting the environment variable `VIGILANT_USER_AGENT`.
+
+| Name                  | Description                          |
+| --------------------- | ------------------------------------ |
+| `VIGILANT_USER_AGENT` | User agent to use for HTTP requests. |
+
 ## Feeds File
 
-By default Vigilant looks for a `feeds.yaml` file in the project's main folder, this behavior can be overridden by setting the environment variable `VIGILANT_FEEDS_FILE`.
+By default, Vigilant looks for a `feeds.yaml` file in the project's main folder, this behaviour can be overridden by setting the environment variable `VIGILANT_FEEDS_FILE`.
 
 | Name                  | Description                  |
 | --------------------- | ---------------------------- |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,7 +14,7 @@ By default, Vigilant uses the timezone of the host system or UTC when running in
 
 ## User agent
 
-By default, Vigilant uses the user agent `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)` when fetching feeds, this behaviour can be overridden by setting the environment variable `VIGILANT_USER_AGENT`. The user agent can also be controlled on a per-feed basis via [feeds.yaml](./feeds.md).
+By default, Vigilant uses the user agent `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)` when fetching feeds, this behaviour can be overridden by setting the environment variable `VIGILANT_USER_AGENT`. The user agent can also be controlled on a per-feed basis via [feeds config file](./feeds.md).
 
 | Name                  | Description                          |
 | --------------------- | ------------------------------------ |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,7 +14,7 @@ By default, Vigilant uses the timezone of the host system or UTC when running in
 
 ## User agent
 
-By default, Vigilant uses the user agent `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)` when fetching feeds, this behaviour can be overridden by setting the environment variable `VIGILANT_USER_AGENT`.
+By default, Vigilant uses the user agent `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)` when fetching feeds, this behaviour can be overridden by setting the environment variable `VIGILANT_USER_AGENT`. The user agent can also be controlled on a per-feed basis via [feeds.yaml](./feeds.md).
 
 | Name                  | Description                          |
 | --------------------- | ------------------------------------ |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,7 +14,7 @@ By default, Vigilant uses the timezone of the host system or UTC when running in
 
 ## User agent
 
-By default, Vigilant uses the user agent `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)` when fetching feeds, this behaviour can be overridden by setting the environment variable `VIGILANT_USER_AGENT`. The user agent can also be controlled on a per-feed basis via [feeds config file](./feeds.md).
+By default, Vigilant uses the user agent `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)` when fetching feeds, this behaviour can be overridden by setting the environment variable `VIGILANT_USER_AGENT`. The user agent can also be set on a per-feed basis via [feeds config file](./feeds.md).
 
 | Name                  | Description                          |
 | --------------------- | ------------------------------------ |

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -26,15 +26,16 @@ feeds:
 
 ### Standard
 
-| Name              | Required | Type    | Description                                                                                     |
-| ----------------- | -------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `name`            | **Yes**  | string  | Feed name                                                                                       |
-| `url`             | **Yes**  | string  | Feed URL                                                                                        |
-| `interval`        | **Yes**  | integer | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).                    |
-| `title_prefix`    | No       | string  | Text to prepend to notification titles.                                                         |
-| `title_override`  | No       | string  | Text to use as notification title, overrides value from RSS/ATOM/JSON feed.                     |
-| `truncate`        | No       | boolean | Truncate notification text. Disabled by default. Use `truncate_length` to set custom length.    |
-| `truncate_length` | No       | integer | Number of characters to truncate notification text to. Minimum is `0` and the default is `200`. |
+| Name              | Required | Type    | Description                                                                                        |
+| ----------------- | -------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `name`            | **Yes**  | string  | Feed name                                                                                          |
+| `url`             | **Yes**  | string  | Feed URL                                                                                           |
+| `interval`        | **Yes**  | integer | Interval between feed checks in seconds. Minimum value is `300` (5 minutes).                       |
+| `title_prefix`    | No       | string  | Text to prepend to notification titles.                                                            |
+| `title_override`  | No       | string  | Text to use as notification title, overrides value from RSS/ATOM/JSON feed.                        |
+| `truncate`        | No       | boolean | Truncate notification text. Disabled by default. Use `truncate_length` to set custom length.       |
+| `truncate_length` | No       | integer | Number of characters to truncate notification text to. Minimum is `0` and the default is `200`.    |
+| `user_agent`      | No       | string  | User agent string to use when fetching feeds. Overrides default value and/or environment variable. |
 
 ### Notification services
 

--- a/src/Check.php
+++ b/src/Check.php
@@ -92,7 +92,10 @@ final class Check
                 $this->details->getUrl()
             ));
 
-            $result = $this->fetch->get($this->details->getUrl());
+            $result = $this->fetch->get(
+                $this->details->getUrl(),
+                $this->details->getUserAgent()
+            );
 
             $this->process($result);
             $this->cache->resetErrorCount();

--- a/src/Config.php
+++ b/src/Config.php
@@ -39,11 +39,14 @@ class Config
 
     public function __construct()
     {
-        $this->validate = new Validator($this->defaults);
+        $defaults = $this->defaults;
+        $defaults['user_agent'] = UserAgent::getDefault();
+
+        $this->validate = new Validator($defaults);
         $this->validate->version(PHP_VERSION, $this->minPhpVersion);
         $this->validate->extensions($this->extensions);
 
-        $this->config = $this->defaults;
+        $this->config = $defaults;
         $this->config['timezone'] = date_default_timezone_get();
         $this->config['feeds_file'] = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'feeds.yaml';
     }
@@ -57,6 +60,7 @@ class Config
 
         $this->validate->verbose();
         $this->validate->timezone();
+        $this->validate->userAgent();
         $this->validate->folder($this->getCachePath());
         $this->validate->feedsFile();
         $this->validate->notificationService($this->notificationServices);

--- a/src/Config.php
+++ b/src/Config.php
@@ -87,6 +87,16 @@ class Config
     }
 
     /**
+     * Returns user agent
+     *
+     * @return string
+     */
+    public function getUserAgent(): string
+    {
+        return $this->config['user_agent'];
+    }
+
+    /**
      * Returns enabled notification service
      *
      * @return string

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -93,6 +93,22 @@ class Validator extends AbstractValidator
     }
 
     /**
+     * Check `VIGILANT_USER_AGENT`
+     *
+     * @throws ConfigException if user agent env has no value
+     */
+    public function userAgent(): void
+    {
+        if ($this->hasEnv('USER_AGENT') === true) {
+            if ($this->getEnv('USER_AGENT') === '') {
+                throw new ConfigException('No user agent string given [VIGILANT_USER_AGENT]');
+            }
+
+            $this->config['user_agent'] = $this->getEnv('USER_AGENT');
+        }
+    }
+
+    /**
      * Check `VIGILANT_FEEDS_FILE`
      *
      * @throws ConfigException if feeds file is not found

--- a/src/Feed/Details.php
+++ b/src/Feed/Details.php
@@ -78,6 +78,16 @@ final class Details
     }
 
     /**
+     * Returns user agent
+     *
+     * @return ?string
+     */
+    public function getUserAgent(): ?string
+    {
+        return $this->details['user_agent'] ?? null;
+    }
+
+    /**
      * Returns gotify server url
      *
      * @return ?string

--- a/src/Feed/Feed.php
+++ b/src/Feed/Feed.php
@@ -58,7 +58,7 @@ final class Feed
         $this->details = new Details($validate->get());
         $this->check = new Check(
             $this->details,
-            new Fetch(),
+            new Fetch($this->config->getUserAgent()),
             $this->config,
             $this->logger
         );

--- a/src/Feed/Feed.php
+++ b/src/Feed/Feed.php
@@ -55,10 +55,11 @@ final class Feed
             $this->config->getMinCheckInterval()
         );
 
+        $fetch = new Fetch($this->config->getUserAgent());
         $this->details = new Details($validate->get());
         $this->check = new Check(
             $this->details,
-            new Fetch($this->config->getUserAgent()),
+            $fetch,
             $this->config,
             $this->logger
         );

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -26,8 +26,6 @@ final class Validate
     ];
 
     /**
-     * Constructor
-     *
      * @param array<string, mixed> $feed
      * @param int $minCheckInterval Minimum feed check interval
      */
@@ -51,6 +49,7 @@ final class Validate
         $this->ntfyToken();
         $this->ntfyPriority();
 
+        $this->userAgent();
         $this->activeHours();
     }
 
@@ -314,6 +313,22 @@ final class Validate
                     sprintf('Non-integer Ntfy priority given for feed: %s', $this->details['name'])
                 );
             }
+        }
+    }
+
+    /**
+     * Validate entry user agent
+     *
+     * @throws FeedsException if user agent string is empty
+     */
+    private function userAgent()
+    {
+        if (array_key_exists('user_agent', $this->details) === true) {
+            if ($this->details['user_agent'] === null || $this->details['user_agent'] === '') {
+                throw new FeedsException(sprintf('Empty user agent string given for feed: %s', $this->details['name']));
+            }
+
+            $this->details['user_agent'] = (string) $this->details['user_agent'];
         }
     }
 

--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -321,7 +321,7 @@ final class Validate
      *
      * @throws FeedsException if user agent string is empty
      */
-    private function userAgent()
+    private function userAgent(): void
     {
         if (array_key_exists('user_agent', $this->details) === true) {
             if ($this->details['user_agent'] === null || $this->details['user_agent'] === '') {

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -42,7 +42,7 @@ class Fetch
     public function get(string $url, ?string $useragent = null): Result
     {
         try {
-           $client = $this->client;
+            $client = $this->client;
 
             if ($useragent !== null) {
                 $headers = $this->headers;

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -6,12 +6,11 @@ namespace Vigilant;
 
 use FeedIo\FeedIo;
 use FeedIo\Reader\Result;
-use GuzzleHttp\Client;
 use Vigilant\Exception\FetchException;
 
 class Fetch
 {
-    private FeedIo $feedIo;
+    private \FeedIo\Adapter\Http\Client $client;
 
     /** @var array<string, string> $headers HTTP headers */
     private array $headers = [
@@ -20,30 +19,41 @@ class Fetch
     ];
 
     /**
-     * @param null|Client $httpClient Custom GuzzleHttp client
+     * @param null|\GuzzleHttp\Client $httpClient Custom GuzzleHttp client
      */
     public function __construct(?\GuzzleHttp\Client $httpClient = null)
     {
-        if (is_null($httpClient) === true) {
+        if ($httpClient === null) {
             $httpClient = new \GuzzleHttp\Client(['headers' => $this->headers]);
         }
 
-        $client = new \FeedIo\Adapter\Http\Client($httpClient);
-        $this->feedIo = new \FeedIo\FeedIo($client);
+        $this->client = new \FeedIo\Adapter\Http\Client($httpClient);
     }
 
     /**
      * Get RSS feed
      *
      * @param string $url Feed URL
+     * @param string $useragent User agent string
      * @return \FeedIo\Reader\Result
      *
      * @throws FetchException if request failed
      */
-    public function get(string $url): Result
+    public function get(string $url, ?string $useragent = null): Result
     {
         try {
-            return $this->feedIo->read($url);
+           $client = $this->client;
+
+            if ($useragent !== null) {
+                $headers = $this->headers;
+                $headers['User-Agent'] = $useragent;
+
+                $client = new \FeedIo\Adapter\Http\Client(
+                    new \GuzzleHttp\Client($headers)
+                );
+            }
+
+            return (new \FeedIo\FeedIo($client))->read($url);
         } catch (\FeedIo\Reader\ReadErrorException $err) {
             switch ($err->getMessage()) {
                 case 'not found':

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -14,15 +14,17 @@ class Fetch
 
     /** @var array<string, string> $headers HTTP headers */
     private array $headers = [
-        'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; rv:146.0) Gecko/20100101 Firefox/146.0',
         'Accept' => '*/*'
     ];
 
     /**
+     * @param string $userAgent Default user-agent string or from environment variable `VIGILANT_USER_AGENT`
      * @param null|\GuzzleHttp\Client $httpClient Custom GuzzleHttp client
      */
-    public function __construct(?\GuzzleHttp\Client $httpClient = null)
+    public function __construct(string $userAgent, ?\GuzzleHttp\Client $httpClient = null)
     {
+        $this->headers['User-Agent'] = $userAgent;
+
         if ($httpClient === null) {
             $httpClient = new \GuzzleHttp\Client(['headers' => $this->headers]);
         }

--- a/src/UserAgent.php
+++ b/src/UserAgent.php
@@ -4,7 +4,7 @@ namespace Vigilant;
 
 class UserAgent
 {
-	/**
+    /**
      * Returns default user-agent string `Vigilant/VERSION (https://github.com/VerifiedJoseph/vigilant)`
      * @return string
      */

--- a/src/UserAgent.php
+++ b/src/UserAgent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Vigilant;
+
+class UserAgent
+{
+	/**
+     * Returns default user-agent string `Vigilant/VERSION (https://github.com/VerifiedJoseph/vigilant)`
+     * @return string
+     */
+    public static function getDefault(): string
+    {
+        return sprintf('Vigilant/%s (https://github.com/VerifiedJoseph/vigilant)', Version::get());
+    }
+}

--- a/src/UserAgent.php
+++ b/src/UserAgent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Vigilant;
 
 class UserAgent

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -54,6 +54,7 @@ class CheckTest extends TestCase
         $config->method('getCachePath')->willReturn(mockfs::getUrl('/'));
         $config->method('getCacheFormatVersion')->willReturn(1);
         $config->method('getTimezone')->willReturn('UTC');
+        $config->method('getUserAgent')->willReturn('Vigilant/Test (https://github.com/VerifiedJoseph/vigilant)');
         self::$config = $config;
 
         self::$logger = new Logger('UTC');
@@ -70,7 +71,12 @@ class CheckTest extends TestCase
     public function testIsDue(): void
     {
         $details = new Details($this->feed);
-        $check = new check($details, new Fetch(), self::$config, self::$logger);
+        $check = new check(
+            $details,
+            new Fetch(self::$config->getUserAgent()),
+            self::$config,
+            self::$logger
+        );
 
         $this->assertTrue($check->isDue());
     }
@@ -81,7 +87,12 @@ class CheckTest extends TestCase
     public function testGetNextCheckDate(): void
     {
         $details = new Details($this->feed);
-        $check = new check($details, new Fetch(), self::$config, self::$logger);
+        $check = new check(
+            $details,
+            new Fetch(self::$config->getUserAgent()),
+            self::$config,
+            self::$logger
+        );
 
         $this->assertEquals('1970-01-01 00:00:00', $check->getNextCheckDate());
     }
@@ -94,9 +105,12 @@ class CheckTest extends TestCase
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, body: (string) file_get_contents('tests/files/rss-feed.xml'))
         ]);
-        $fetch = new Fetch(new \GuzzleHttp\Client([
-            'handler' => GuzzleHttp\HandlerStack::create($mock)
-        ]));
+        $fetch = new Fetch(
+            self::$config->getUserAgent(),
+            new \GuzzleHttp\Client([
+                'handler' => GuzzleHttp\HandlerStack::create($mock)
+            ])
+        );
 
         $details = new Details($this->feed);
         $check = new check($details, $fetch, self::$config, self::$logger);
@@ -118,9 +132,12 @@ class CheckTest extends TestCase
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, body: (string) file_get_contents('tests/files/rss-feed.xml'))
         ]);
-        $fetch = new Fetch(new \GuzzleHttp\Client([
-            'handler' => GuzzleHttp\HandlerStack::create($mock)
-        ]));
+        $fetch = new Fetch(
+            self::$config->getUserAgent(),
+            new \GuzzleHttp\Client([
+                'handler' => GuzzleHttp\HandlerStack::create($mock)
+            ])
+        );
 
         $details = new Details($this->feed);
         $check = new check($details, $fetch, self::$config, self::$logger);
@@ -148,9 +165,12 @@ class CheckTest extends TestCase
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, body: (string) file_get_contents('tests/files/rss-feed.xml'))
         ]);
-        $fetch = new Fetch(new \GuzzleHttp\Client([
-            'handler' => GuzzleHttp\HandlerStack::create($mock)
-        ]));
+        $fetch = new Fetch(
+            self::$config->getUserAgent(),
+            new \GuzzleHttp\Client([
+                'handler' => GuzzleHttp\HandlerStack::create($mock)
+            ])
+        );
 
         $details = new Details($feed);
         $check = new check($details, $fetch, self::$config, self::$logger);
@@ -177,9 +197,13 @@ class CheckTest extends TestCase
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(404),
         ]);
-        $fetch = new Fetch(new \GuzzleHttp\Client([
-            'handler' => GuzzleHttp\HandlerStack::create($mock)
-        ]));
+        $fetch = new Fetch(
+            self::$config->getUserAgent(),
+            new \GuzzleHttp\Client([
+                'handler' => GuzzleHttp\HandlerStack::create($mock)
+            ])
+        );
+
         $details = new Details($this->feed);
         $check = new check($details, $fetch, self::$config, self::$logger);
 

--- a/tests/Config/ValidatorTest.php
+++ b/tests/Config/ValidatorTest.php
@@ -151,6 +151,34 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Test `userAgent()`
+     */
+    public function testUserAgent(): void
+    {
+        putenv('VIGILANT_USER_AGENT=testing');
+
+        $validate = new Validator(self::$defaults);
+        $validate->userAgent();
+        $config = $validate->getConfig();
+
+        $this->assertEquals('testing', $config['user_agent']);
+    }
+
+    /**
+     * Test `userAgent()` with empty useragent string
+     */
+    public function testEmptyUserAgent(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('No user agent string given');
+
+        putenv('VIGILANT_USER_AGENT=');
+
+        $validate = new Validator(self::$defaults);
+        $validate->userAgent();
+    }
+
+    /**
      * Test `feedsFile()`
      */
     public function testFeedsFile(): void

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -75,6 +75,18 @@ class ConfigTest extends TestCase
     }
 
     /**
+     * Test `getUserAgent()`
+     */
+    public function testGetUserAgent(): void
+    {
+        $config = new Config();
+        $this->assertEquals(
+            self::$defaults['user_agent'],
+            $config->getUserAgent()
+        );
+    }
+
+    /**
      * Test `getNotificationService()`
      */
     public function testGetNotificationService(): void

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,6 +12,7 @@ use ReflectionClass;
 
 #[CoversClass(Config::class)]
 #[CoversClass(Version::class)]
+#[UsesClass(\Vigilant\UserAgent::class)]
 #[UsesClass(\Vigilant\Config\Validator::class)]
 #[UsesClass(\Vigilant\Config\Validate\Ntfy::class)]
 #[UsesClass(\Vigilant\Config\AbstractValidator::class)]

--- a/tests/Feed/DetailsTest.php
+++ b/tests/Feed/DetailsTest.php
@@ -125,6 +125,21 @@ class DetailsTest extends TestCase
     }
 
     /**
+     * Test getUserAgent()
+     */
+    public function testGetUserAgent(): void
+    {
+        $this->assertEquals(
+            self::$feeds[0]['user_agent'],
+            self::$details[0]->getUserAgent()
+        );
+
+        $this->assertNull(
+            self::$details[1]->getUserAgent()
+        );
+    }
+
+    /**
      * Test getGotifyUrl()
      */
     public function testGetGotifyUrl(): void

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -27,6 +27,20 @@ class FetchTest extends TestCase
     }
 
     /**
+     * Test `get()` with custom useragent
+     */
+    public function testGetWithCustomUseragent(): void
+    {
+        $fetch = new Fetch();
+        $result = $fetch->get(
+            'https://www.githubstatus.com/history.rss',
+            'Mozilla/5.0 (Windows NT 10.0; rv:146.0) Gecko/20100101 Firefox/146.0'
+        );
+
+        $this->assertInstanceOf(FeedIo\Reader\Result::class, $result);
+    }
+
+    /**
      * Test `get()` with mock handler that does not return a rss feed
      */
     public function testGetParseError(): void

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -15,12 +15,14 @@ use FeedIo;
 #[UsesClass(FetchException::class)]
 class FetchTest extends TestCase
 {
+    private string $userAgent = 'Vigilant/Test (https://github.com/VerifiedJoseph/vigilant)';
+
     /**
      * Test `get()`
      */
     public function testGet(): void
     {
-        $fetch = new Fetch();
+        $fetch = new Fetch($this->userAgent);
         $result = $fetch->get('https://www.githubstatus.com/history.rss');
 
         $this->assertInstanceOf(FeedIo\Reader\Result::class, $result);
@@ -31,7 +33,7 @@ class FetchTest extends TestCase
      */
     public function testGetWithCustomUseragent(): void
     {
-        $fetch = new Fetch();
+        $fetch = new Fetch($this->userAgent);
         $result = $fetch->get(
             'https://www.githubstatus.com/history.rss',
             'Mozilla/5.0 (Windows NT 10.0; rv:146.0) Gecko/20100101 Firefox/146.0'
@@ -45,15 +47,19 @@ class FetchTest extends TestCase
      */
     public function testGetParseError(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Failed to parse feed');
+
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(200, body: 'Hello, World'),
         ]);
         $handlerStack = GuzzleHttp\HandlerStack::create($mock);
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Failed to parse feed');
+        $fetch = new Fetch(
+            $this->userAgent,
+            new \GuzzleHttp\Client(['handler' => $handlerStack])
+        );
 
-        $fetch = new Fetch(new \GuzzleHttp\Client(['handler' => $handlerStack]));
         $fetch->get('http://example.invalid');
     }
 
@@ -62,15 +68,19 @@ class FetchTest extends TestCase
      */
     public function testGetServerError(): void
     {
+        $this->expectException(FetchException::class);
+        $this->expectExceptionMessage('ailed to fetch: http://example.invalid (500 Internal Server Error)');
+
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(500, body: 'server error'),
         ]);
         $handlerStack = GuzzleHttp\HandlerStack::create($mock);
 
-        $this->expectException(FetchException::class);
-        $this->expectExceptionMessage('ailed to fetch: http://example.invalid (500 Internal Server Error)');
+        $fetch = new Fetch(
+            $this->userAgent,
+            new \GuzzleHttp\Client(['handler' => $handlerStack])
+        );
 
-        $fetch = new Fetch(new GuzzleHttp\Client(['handler' => $handlerStack]));
         $fetch->get('http://example.invalid');
     }
 
@@ -79,15 +89,19 @@ class FetchTest extends TestCase
      */
     public function testGetNotFoundError(): void
     {
+        $this->expectException(FetchException::class);
+        $this->expectExceptionMessage('Failed to fetch: http://example.invalid (404 Not Found)');
+
         $mock = new GuzzleHttp\Handler\MockHandler([
             new GuzzleHttp\Psr7\Response(404, body: 'not found'),
         ]);
         $handlerStack = GuzzleHttp\HandlerStack::create($mock);
 
-        $this->expectException(FetchException::class);
-        $this->expectExceptionMessage('Failed to fetch: http://example.invalid (404 Not Found)');
+        $fetch = new Fetch(
+            $this->userAgent,
+            new \GuzzleHttp\Client(['handler' => $handlerStack])
+        );
 
-        $fetch = new Fetch(new GuzzleHttp\Client(['handler' => $handlerStack]));
         $fetch->get('http://example.invalid');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,7 +43,7 @@ abstract class TestCase extends BaseTestCase
         // Unset environment variables before each test
         putenv('VIGILANT_VERBOSE');
         putenv('VIGILANT_TIMEZONE');
-        putenv('VIGILANT_USERAGENT');
+        putenv('VIGILANT_USER_AGENT');
         putenv('VIGILANT_FEEDS_FILE');
         putenv('VIGILANT_NOTIFICATION_SERVICE');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,6 +43,7 @@ abstract class TestCase extends BaseTestCase
         // Unset environment variables before each test
         putenv('VIGILANT_VERBOSE');
         putenv('VIGILANT_TIMEZONE');
+        putenv('VIGILANT_USERAGENT');
         putenv('VIGILANT_FEEDS_FILE');
         putenv('VIGILANT_NOTIFICATION_SERVICE');
 

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use Vigilant\UserAgent;
+use Vigilant\Version;
+
+#[CoversClass(UserAgent::class)]
+#[UsesClass(Version::class)]
+class UserAgentTest extends TestCase
+{
+    public function testGetDefault(): void
+    {
+        $expected = sprintf(
+            'Vigilant/%s (https://github.com/VerifiedJoseph/vigilant)',
+            Version::get()
+        );
+
+        $this->assertEquals($expected, UserAgent::getDefault());
+    }
+}

--- a/tests/files/feeds-invalid.yaml
+++ b/tests/files/feeds-invalid.yaml
@@ -68,6 +68,14 @@ feeds:
       interval: 300
       title_prefix:
 
+  emptyUserAgent:
+    exception: Empty user agent string given
+    data:
+      name: Example.com Feed
+      url: https://www.example.com/feed.rss
+      interval: 300
+      user_agent:
+
   emptyGotifyUrl:
     exception: Empty Gotify url given
     data:

--- a/tests/files/feeds.yaml
+++ b/tests/files/feeds.yaml
@@ -8,6 +8,7 @@ feeds:
      gotify_url: https://gotify.example.com
      gotify_token: 7ZHeHM3awd45rn9W
      gotify_priority: 1
+     user_agent: RssBob/v1
     -
      name: GitHub status
      url: https://www.githubstatus.com/history.rss


### PR DESCRIPTION
- Adds support for setting a custom user agent via env `VIGILANT_USER_AGENT`.
- Adds support for custom user agents for feeds via feeds.yaml
- Changes the default user agent string to `Vigilant/VERSION_NUMBER (https://github.com/VerifiedJoseph/vigilant)`. 