### PR TITLE
Rework caching to prevent duplicate notifications

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -166,13 +166,13 @@ final class Cache
     }
 
     /**
-     * Update item hashes
+     * Add item hashes
      *
-     * @param array<int, string> $items item hashes
+     * @param array<string> $items item hashes
      */
-    public function updateItems(array $items): void
+    public function addItems(array $items): void
     {
-        $this->items = $items;
+        $this->items = $this->items + $items;
     }
 
     /**

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -172,7 +172,7 @@ final class Cache
      */
     public function addItems(array $items): void
     {
-        $this->items = $this->items + $items;
+        $this->items = $items + $this->items;
     }
 
     /**

--- a/src/Check.php
+++ b/src/Check.php
@@ -139,9 +139,9 @@ final class Check
 
         foreach ($result->getFeed() as $item) {
             $hash = sha1($item->getLink());
-            $itemHashes[] = $hash;
 
             if (in_array($hash, $this->cache->getItems()) === false) {
+                $itemHashes[] = $hash;
                 $newItems += 1;
 
                 $title = html_entity_decode($this->details->getTitleOverride() ?? $item->getTitle());
@@ -164,7 +164,7 @@ final class Check
 
         $this->logger->info(sprintf('Found %s new item(s).', $newItems));
 
-        $this->cache->updateItems($itemHashes);
+        $this->cache->addItems($itemHashes);
 
         if ($newItems > 0 && $this->cache->isFirstCheck() === true) {
             $this->logger->info('First feed check, not sending notifications for found items.');

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -238,15 +238,17 @@ class CacheTest extends TestCase
     }
 
     /**
-     * Test UpdateItems()
+     * Test addItems()
      */
-    public function testUpdateItems(): void
+    public function testAddItems(): void
     {
         $items = ['iUz0s3QaHS', 'QwZF6yVJVu'];
-        self::$cache->updateItems($items);
+        $expected = self::$cache->getItems() + $items;
+
+        self::$cache->addItems($items);
 
         $this->assertEquals(
-            $items,
+            $expected,
             self::$cache->getItems()
         );
     }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -243,7 +243,7 @@ class CacheTest extends TestCase
     public function testAddItems(): void
     {
         $items = ['iUz0s3QaHS', 'QwZF6yVJVu'];
-        $expected = self::$cache->getItems() + $items;
+        $expected = $items + self::$cache->getItems();
 
         self::$cache->addItems($items);
 


### PR DESCRIPTION
Reworks adding items to cache to prevent duplicate notifications. fixes #547