### PR TITLE
Feed\Validate: Fix undefined array key warning

### DIFF
--- a/src/Feed/Validate.php
+++ b/src/Feed/Validate.php
@@ -168,12 +168,8 @@ final class Validate
             $this->details['truncate'] = $truncate;
         }
 
-        if ($this->details['truncate'] === true) {
-            if (
-                array_key_exists('truncate', $this->details) === false ||
-                $this->details['truncate_length'] === null ||
-                $this->details['truncate_length'] === ''
-            ) {
+        if ($this->details['truncate'] === true && array_key_exists('truncate_length', $this->details) === true) {
+            if ($this->details['truncate_length'] === null || $this->details['truncate_length'] === '') {
                 throw new FeedsException(
                     sprintf('No truncate length given for feed: %s', $this->details['truncate_length'])
                 );

--- a/src/Message.php
+++ b/src/Message.php
@@ -35,7 +35,7 @@ class Message
         $this->prefix = $prefix;
         $this->truncate = $truncate;
 
-        if (is_null($truncateLength) === false && $truncateLength >= 0) {
+        if (is_null($truncateLength) === false && 0 < $truncateLength) {
             $this->truncateLength = $truncateLength;
         }
     }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -81,6 +81,21 @@ class MessageTest extends TestCase
     }
 
     /**
+     * Test message truncation with text with truncation length of zero
+     */
+    public function testTruncationWithTruncationZeroLength(): void
+    {
+        $message = new Message(
+            title: '',
+            body: 'Hello World',
+            truncate: true,
+            truncateLength: 0
+        );
+
+        $this->assertEquals('Hello World', $message->getBody());
+    }
+
+    /**
      * Test message truncation with text that is shorter than given truncation length
      */
     public function testTruncationWithTextShorterThatTruncationLength(): void


### PR DESCRIPTION
Fixes undefined array key warning when array element `truncate` exists but `truncate_length` does not.